### PR TITLE
feat: passthrough MAX_JOBS and CORES to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM nixos/nix:2.18.8
 
+# default build args
+ARG MAX_JOBS=4
+ARG CORES=4
+
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
+    && echo "max-jobs = $MAX_JOBS" >> /etc/nix/nix.conf \
+    && echo "cores = $CORES" >> /etc/nix/nix.conf \
     && nix profile install nixpkgs#cachix \
     && cachix use kernel-builder
 
 WORKDIR /kernelcode
 COPY . /etc/kernel-builder/
 
-ENTRYPOINT ["/bin/sh", "-c", "nix build --impure --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L"]
+ENTRYPOINT ["/bin/sh", "-c", "nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ docker run --rm \
 # this will build the kernel and save the output in the `build` directory in the activation folder
 ```
 
+### Docker Arguments
+
+The kernel builder can be configured using the following arguments:
+
+| Argument   | Description                                                         | Default |
+| ---------- | ------------------------------------------------------------------- | ------- |
+| `MAX_JOBS` | The maximum number of parallel jobs to run during the build process | `4`     |
+| `CORES`    | The number of cores to use during the build process                 | `4`     |
+
+```bash
+docker run --rm \
+    -v $(pwd):/kernelcode \
+    -e MAX_JOBS=8 \
+    -e CORES=8 \
+    ghcr.io/huggingface/kernel-builder:latest
+```
+
 ## Final Output
 
 The whole goal of building these kernels is to allow researchers, developers, and programmers to use high performance kernels in their code PyTorch code. The final output of the kernel builder is a `.so` file that can be loaded in PyTorch using the `torch.ops.load_library` function.


### PR DESCRIPTION
This PR simply passes `MAX_JOBS` and `CORES` env to the dockfile at runtime as build args, if no values are supplied they will default to 4