### PR TITLE
Only use capabilities that are supported by a CUDA version

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -40,11 +40,11 @@ rec {
         name = "${name}-src";
         filter = srcFilter buildConfig.src;
       };
+      cudaCapabilities = lib.intersectLists pkgs.cudaPackages.flags.cudaCapabilities buildConfig.capabilities;
     in
     pkgs.callPackage ./kernel {
-      inherit src;
+      inherit cudaCapabilities src;
       kernelName = name;
-      cudaCapabilities = buildConfig.capabilities;
       kernelSources = buildConfig.src;
       kernelDeps = resolveDeps {
         inherit pkgs torch;


### PR DESCRIPTION
This avoids e.g. attempting to build for capability 9.0a on CUDA 11.