### PR TITLE
Fix CMake `KERNEL_LIBRARIES` variable when buiding multiple kernels

### DIFF
--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
       (lib.cmakeFeature "EXTENSION_NAME" "_${extensionName}_${flatVersion}")
       (lib.cmakeFeature "EXTENSION_DEST" extensionName)
       (lib.cmakeFeature "EXTENSION_SOURCES" (lib.concatStringsSep ";" extensionSources))
-      (lib.cmakeFeature "KERNEL_LIBRARIES" (lib.concatStringsSep " " kernelLibs))
+      (lib.cmakeFeature "KERNEL_LIBRARIES" (lib.concatStringsSep ";" kernelLibs))
     ];
 
   postInstall =


### PR DESCRIPTION
An incorrect separator was used. Every kernel path except the first was interpreted as an additional (ignored) argument.