### PR TITLE
_ops: add a function to get a properly prefixed op name

### DIFF
--- a/lib/torch-extension/_ops.py.in
+++ b/lib/torch-extension/_ops.py.in
@@ -1,3 +1,9 @@
 import torch
 from . import _@EXTENSION_NAME@
 ops = torch.ops._@EXTENSION_NAME@
+
+def add_op_namespace_prefix(op_name: str):
+    """
+    Prefix op by namespace.
+    """
+    return f"_@EXTENSION_NAME@::{op_name}"


### PR DESCRIPTION
This is useful for registering fake ops.