### PR TITLE
Add support for old Linux distributions

### DIFF
--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -1,0 +1,79 @@
+# Toolchain
+
+## ABI compatibility
+
+Kernels and kernel extensions typically do not have any explicit external
+dependencies, except:
+
+- The CUDA library version that they were compiled against.
+- The Torch version that they were compiled against.
+- The C and C++ standard libraries (glibc and libstdc++ in Linux).
+- The Python library.
+
+Of course, the versions on a user's system can differ from the build
+system, so we have to account for these dependencies.
+
+### Python
+
+In the case of Python we use the [limited API](https://docs.python.org/3/c-api/stable.html#limited-c-api).
+For the limited API, ABI stability it guaranteed. This excludes the
+possibility to use some dependencies like pybind11, but since it
+reduces the number of builds drastically, we use it anyway.
+
+### CUDA/Torch
+
+Torch and CUDA only have limited ABI compatibility. Therefore, we
+compile extensions for all supported CUDA/Torch combinations.
+
+### glibc/libstdc++
+
+glibc and libstdc++ use symbol versioning. As a result, a binary or
+library compiled against an older version of these libraries work
+on newer versions (modulo the C++11 ABI change). It is however,
+not possible to use only older symbol versions when building against
+a newer version of these libraries.
+
+The traditional solution to this problem is to build software in
+a container that uses an ancient Linux distribution with old
+glibc/libstdc++ versions.
+
+With Nix we can do better --- with some work we can compile for old
+versions of these libraries using a recent nixpkgs. There are several
+nuances:
+
+- libstdc++ is distributed with gcc, so it has the same library version.
+- CUDA's nvcc uses a 'backend stdenv'. This stdenv has the latest
+  gcc that is supported by nvcc. It can differ from the default gcc,
+  because gcc in nixpkgs is sometimes newer than the version supported
+  by CUDA.
+- gcc also links a binary against libgcc. libgcc must also be compiled
+  against the target glibc, otherwise the resulting extensions will
+  still rely on symbols from newer glibc versions.
+
+With that in mind, there are (at least?) three ways to do this:
+
+1. Override glibc and libstdc++ system-wide using an overlay.
+2. Override the backend stdenv of CUDA with one that has older
+   library versions.
+3. Only override glibc and libstdc++ through the stdenv for
+   the kernel/extension packages.
+
+(1) is the most principled approach -- it guarantees that all packages
+use the same library versions, making it impossible for a newer version
+to creep in. Unfortunately, this has many issues, libraries and
+derivations from simply don't interoperate well with a package set from 2024.
+For instance, the build of older glibc versions hangs with GNU
+make >= 4.4 due to some dependency cycle.
+
+Overriding the backend stdenv of CUDA (2) has the issue that some
+derivations end up with two versions. E.g. they would build using the
+headers of the latest glibc and then try to link against the old glibc.
+
+Finally, (3) seems to work really well. We build everything except
+the kernels and extensions using unmodified nixpkgs. Then we tell nvcc
+to use our modified stdenv using CMake.
+
+To make this possible, we import the glibc and libstd++ derivations
+from an old nixpkgs. We then create an intermediate stdenv to rebuild
+gcc/libgcc against the old glibc. Then glibc, libstdc++, and the
+rebuilt gcc form make a new stdenv together.

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,9 @@
       system:
       let
         # Plain nixkpgs that we use to access utility funtions.
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+        };
         inherit (pkgs) lib;
 
         # Get versions.

--- a/lib/kernel/CMakeLists.txt
+++ b/lib/kernel/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(${KERNEL_NAME} STATIC ${SOURCE_FILES})
 target_compile_options(${KERNEL_NAME} PRIVATE
   $<$<COMPILE_LANGUAGE:CUDA>:${GPU_COMPILE_FLAGS}>)
 
+target_compile_features(${KERNEL_NAME} PRIVATE cxx_std_17)
+
 target_link_libraries(${KERNEL_NAME} PRIVATE ${TORCH_LIBRARIES})
 set_target_properties(${EXTENSION_NAME} PROPERTIES
   CUDA_RESOLVE_DEVICE_SYMBOLS ON)

--- a/lib/kernel/default.nix
+++ b/lib/kernel/default.nix
@@ -7,6 +7,7 @@
   src,
 
   lib,
+  stdenv ? cudaPackages.backendStdenv,
   cudaPackages,
   cmake,
   ninja,
@@ -17,7 +18,6 @@
 
 let
   dropDot = builtins.replaceStrings [ "." ] [ "" ];
-  stdenv = cudaPackages.backendStdenv;
 in
 stdenv.mkDerivation {
   inherit nvccThreads;
@@ -44,10 +44,14 @@ stdenv.mkDerivation {
     TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
   };
 
+  # If we use the default setup, CMAKE_CUDA_HOST_COMPILER gets set to nixpkgs g++.
+  dontSetupCUDAToolkitCompilers = true;
+
   cmakeFlags = [
     (lib.cmakeFeature "KERNEL_NAME" kernelName)
     (lib.cmakeFeature "KERNEL_SOURCES" (lib.concatStringsSep ";" kernelSources))
     (lib.cmakeFeature "KERNEL_INCLUDE_DIRS" (lib.concatStringsSep ";" kernelInclude))
     (lib.cmakeFeature "CMAKE_CUDA_ARCHITECTURES" (dropDot (lib.concatStringsSep ";" cudaCapabilities)))
+    (lib.cmakeFeature "CMAKE_CUDA_HOST_COMPILER" "${stdenv.cc}/bin/g++")
   ];
 }

--- a/lib/torch-extension/CMakeLists.txt
+++ b/lib/torch-extension/CMakeLists.txt
@@ -30,8 +30,11 @@ endif()
 
 Python_add_library(${EXTENSION_NAME} USE_SABI 3 WITH_SOABI MODULE "${SOURCE_FILES}")
 target_compile_definitions(${EXTENSION_NAME} PRIVATE "-DTORCH_EXTENSION_NAME=${EXTENSION_NAME}")
-target_link_libraries(${EXTENSION_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver)
 
+
+target_compile_features(${EXTENSION_NAME} PRIVATE cxx_std_17)
+
+target_link_libraries(${EXTENSION_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver)
 target_link_libraries(${EXTENSION_NAME} PRIVATE torch torch_python)
 target_link_libraries(${EXTENSION_NAME} PRIVATE ${KERNEL_LIBRARIES})
 set_target_properties(${EXTENSION_NAME} PROPERTIES

--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -14,6 +14,7 @@
   pySrc,
 
   lib,
+  stdenv ? cudaPackages.backendStdenv,
   cudaPackages,
   cmake,
   ninja,
@@ -23,7 +24,6 @@
 
 let
   flatVersion = lib.replaceStrings [ "." ] [ "_" ] (lib.versions.pad 3 extensionVersion);
-  stdenv = cudaPackages.backendStdenv;
 in
 stdenv.mkDerivation {
   pname = "${extensionName}-torch-ext";
@@ -61,8 +61,10 @@ stdenv.mkDerivation {
 
   env = {
     CUDAToolkit_ROOT = "${lib.getDev cudaPackages.cuda_nvcc}";
-    #TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
   };
+
+  # If we use the default setup, CMAKE_CUDA_HOST_COMPILER gets set to nixpkgs g++.
+  dontSetupCUDAToolkitCompilers = true;
 
   cmakeFlags =
     let
@@ -75,6 +77,7 @@ stdenv.mkDerivation {
       (lib.cmakeFeature "EXTENSION_SOURCES" (lib.concatStringsSep ";" extensionSources))
       (lib.cmakeFeature "EXTENSION_INCLUDE_DIRS" (lib.concatStringsSep ";" extensionInclude))
       (lib.cmakeFeature "KERNEL_LIBRARIES" (lib.concatStringsSep ";" kernelLibs))
+      (lib.cmakeFeature "CMAKE_CUDA_HOST_COMPILER" "${stdenv.cc}/bin/g++")
     ];
 
   postInstall =

--- a/overlay.nix
+++ b/overlay.nix
@@ -23,4 +23,6 @@ final: prev: {
       }
     )
   ];
+
+  stdenvGlibc_2_27 = prev.callPackage ./pkgs/stdenv-glibc-2_27 { };
 }

--- a/pkgs/stdenv-glibc-2_27/default.nix
+++ b/pkgs/stdenv-glibc-2_27/default.nix
@@ -1,0 +1,74 @@
+{
+  fetchFromGitHub,
+  overrideCC,
+  system,
+  wrapBintoolsWith,
+  wrapCCWith,
+  stdenv,
+  bintools-unwrapped,
+  cudaPackages,
+  libgcc,
+}:
+
+let
+  nixpkgs_20191230 = import (fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs";
+    rev = "a9eb3eed170fa916e0a8364e5227ee661af76fde";
+    hash = "sha256-1ycrr9HMrGA3ZDM8qmKcZICBupE5UShnIIhPRWdvAzA=";
+  }) { inherit system; };
+
+  glibc_2_27 = nixpkgs_20191230.glibc.overrideAttrs (prevAttrs: {
+    # Slight adjustments for compatibility with modern nixpkgs:
+    #
+    # - pname is required
+    # - an additional getent output
+    # - passthru libgcc
+
+    pname = "glibc";
+
+    outputs = prevAttrs.outputs ++ [ "getent" ];
+
+    postInstall =
+      prevAttrs.postInstall
+      + ''
+        install -Dm755 $bin/bin/getent -t $getent/bin
+      '';
+
+    passthru = prevAttrs.passthru // {
+      # Should be stdenv's gcc, but we don't have access to it.
+      libgcc = libgcc;
+    };
+  });
+
+  gcc_8_3 = nixpkgs_20191230.gcc;
+
+  stdenvWith =
+    newGlibc: newLibcxx: newGcc: stdenv:
+    let
+      # We need gcc to have a libgcc that is compatible with glibc. We
+      # do this in three steps to avoid an infinite recursion: (1) we
+      # create an stdenv with gcc and glibc; (2) we rebuild glibc using
+      # this stdenv, so that we have a libgcc that is compatible with
+      # glibc; (3) we create the final stdenv that contains the compatible
+      # gcc + glibc.
+      onlyGlibc = overrideCC stdenv (wrapCCWith {
+        cc = newGcc;
+        bintools = wrapBintoolsWith {
+          bintools = bintools-unwrapped;
+          libc = newGlibc;
+        };
+      });
+      compilerWrapped = wrapCCWith {
+        cc = newGcc.override { stdenv = onlyGlibc; };
+        bintools = wrapBintoolsWith {
+          bintools = bintools-unwrapped;
+          libc = newGlibc;
+        };
+        libcxx = newLibcxx;
+      };
+    in
+    overrideCC stdenv compilerWrapped;
+
+in
+stdenvWith glibc_2_27 gcc_8_3.cc.lib cudaPackages.backendStdenv.cc.cc stdenv


### PR DESCRIPTION
Build against glibc 2.27 and libstdc++ 8 to support old Linux distributions (tested Ubuntu 18.04 and later).