### PR TITLE
Add a `forCache` package with all build dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,6 +96,18 @@
               value = buildSet.torch;
             }) buildSets
           );
+
+          # Dependencies that should be cached.
+          forCache =
+            let
+              oldLinuxStdenvs = builtins.listToAttrs (
+                map (buildSet: {
+                  name = "stdenv-${buildVersion buildSet}";
+                  value = buildSet.pkgs.stdenvGlibc_2_27;
+                }) buildSets
+              );
+            in
+            pkgs.linkFarm "packages-for-cache" (torch // oldLinuxStdenvs);
         };
       }
     );


### PR DESCRIPTION
We want to ensure that the binary cache has all build dependencies, so that users do not have to rebuild Torch, gcc, etc. This change creates a `forCache` package that is a linkFarm with all supported Torch versions as well as the modified stdenvs that are used for backwards compat with old Linux versions.