### PR TITLE
toml2cmake: allow `pyext` field in the `torch` section

### DIFF
--- a/toml2cmake/src/config.rs
+++ b/toml2cmake/src/config.rs
@@ -23,6 +23,9 @@ pub struct General {
 pub struct Torch {
     pub name: String,
     pub include: Option<Vec<String>>,
+    // Used by the builder, so we have to accept this field.
+    #[serde(rename = "pyext")]
+    pub _pyext: Option<Vec<String>>,
     pub pyroot: PathBuf,
     pub src: Vec<PathBuf>,
 }


### PR DESCRIPTION
This is used by the builder. We don't need it in toml2cmake, but we need to allow it.