### PR TITLE
Add toml2cmake package to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,8 @@
         formatter = pkgs.nixfmt-rfc-style;
 
         packages = rec {
+          toml2cmake = pkgs.callPackage ./pkgs/toml2cmake {};
+
           # This package set is exposed so that we can prebuild the Torch versions.
           torch = builtins.listToAttrs (
             map (buildSet: {


### PR DESCRIPTION
This enables running `toml2cmake` with `nix run .#toml2cmake`.