### PR TITLE
Use random material to generate unique ops names

### DIFF
--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -22,9 +22,6 @@
   torch,
 }:
 
-let
-  flatVersion = lib.replaceStrings [ "." ] [ "_" ] (lib.versions.pad 3 extensionVersion);
-in
 stdenv.mkDerivation {
   pname = "${extensionName}-torch-ext";
   version = extensionVersion;
@@ -73,17 +70,13 @@ stdenv.mkDerivation {
       (lib.cmakeFeature "Python_EXECUTABLE" "${python3.withPackages (ps: [ torch ])}/bin/python")
     ];
 
-  postInstall =
-    let
-      versionedName = "_${extensionName}_${flatVersion}";
-    in
-    ''
+  postInstall = ''
       (
         cd ..
         cp -r ${pyRoot}/${extensionName} $out/
       )
-      cp $out/${versionedName}/* $out/${extensionName}
-      rm -rf $out/${versionedName}
+      cp $out/_${extensionName}_*/* $out/${extensionName}
+      rm -rf $out/_${extensionName}_*
     ''
     + lib.optionalString stripRPath ''
       find $out/${extensionName} -name '*.so' \

--- a/toml2cmake/Cargo.lock
+++ b/toml2cmake/Cargo.lock
@@ -52,6 +52,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.169"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +249,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -269,11 +343,13 @@ dependencies = [
 name = "toml2cmake"
 version = "0.1.0"
 dependencies = [
+ "base32",
  "clap",
  "eyre",
  "itertools",
  "minijinja",
  "minijinja-embed",
+ "rand",
  "serde",
  "toml",
 ]
@@ -311,6 +387,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -392,4 +474,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/toml2cmake/Cargo.toml
+++ b/toml2cmake/Cargo.toml
@@ -4,11 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+base32 = "0.5"
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6.12"
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
 

--- a/toml2cmake/src/templates/_ops.py
+++ b/toml2cmake/src/templates/_ops.py
@@ -1,9 +1,9 @@
 import torch
-from . import {{ ext_name }}
-ops = torch.ops.{{ ext_name }}
+from . import {{ ops_name }}
+ops = torch.ops.{{ ops_name }}
 
 def add_op_namespace_prefix(op_name: str):
     """
     Prefix op by namespace.
     """
-    return f"{{ ext_name }}::{op_name}"
+    return f"{{ ops_name }}::{op_name}"

--- a/toml2cmake/src/templates/setup.py
+++ b/toml2cmake/src/templates/setup.py
@@ -119,7 +119,7 @@ class CMakeBuild(build_ext):
 setup(
     name="{{ name }}",
     version="{{ version }}",
-    ext_modules=[CMakeExtension("{{ name }}.{{ ext_name }}")],
+    ext_modules=[CMakeExtension("{{ name }}.{{ ops_name }}")],
     cmdclass={"build_ext": CMakeBuild},
     packages=["{{ name }}"],
     package_dir={"{{ name }}": "{{ pyroot }}/{{ name }}"},

--- a/toml2cmake/src/templates/torch-extension.cmake
+++ b/toml2cmake/src/templates/torch-extension.cmake
@@ -18,8 +18,8 @@ set_source_files_properties(
 list(APPEND SRC {{'"${TORCH_' + name + '_SRC}"'}})
 
 define_gpu_extension_target(
-  {{ ext_name }}
-  DESTINATION {{ ext_name }}
+  {{ ops_name }}
+  DESTINATION {{ ops_name }}
   LANGUAGE ${GPU_LANGUAGE}
   SOURCES ${SRC}
   COMPILE_FLAGS ${GPU_FLAGS}
@@ -28,5 +28,5 @@ define_gpu_extension_target(
   USE_SABI 3
   WITH_SOABI)
 
-target_link_options({{ ext_name }} PRIVATE -static-libstdc++)
+target_link_options({{ ops_name }} PRIVATE -static-libstdc++)
 


### PR DESCRIPTION
Using version numbers is probably not safe, because a kernel developer might push a new revision without bumping the version number.