### PR TITLE
CI: Build a kernel and run tests

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -1,0 +1,45 @@
+name: "Build and test kernel"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened] # trigger on PRs
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build kernel
+    runs-on:
+      group: aws-g6-12xlarge-plus
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v14
+        with:
+          name: kernel-builder
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+        env:
+          USER: github_runner
+      - name: Build
+        run: ( cd examples/activation && nix build .\#redistributable.torch25-cxx98-cu121-x86_64-linux )
+      - name: Copy kernel
+        run: cp -rL examples/activation/result kernel
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: tests/Dockerfile.test-kernel
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: kernel-builder:latest
+
+      - name: Run Tests
+        run: |
+          docker run --gpus all kernel-builder:latest

--- a/tests/Dockerfile.test-kernel
+++ b/tests/Dockerfile.test-kernel
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1.4
+ARG PYTHON_VERSION=3.10
+# Ideally we'd test with 11.8, but the GELU kernel is subtly off.
+ARG CUDA_VERSION=12.1.0
+ARG UBUNTU_VERSION=18.04
+ARG TORCH_VERSION=2.5.0
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} as base
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
+    PATH="/root/.local/bin:/root/.cargo/bin:${PATH}" \
+    NVIDIA_VISIBLE_DEVICES=all \
+    NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv package manager
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Set working directory
+WORKDIR /app
+
+# Need to re-declare ARG after FROM for use in RUN
+ARG CUDA_VERSION
+ARG TORCH_VERSION
+ARG PYTHON_VERSION
+
+RUN echo "Building with CUDA_VERSION=${CUDA_VERSION}, TORCH_VERSION=${TORCH_VERSION}, PYTHON_VERSION=${PYTHON_VERSION}"
+
+# Initialize uv and create virtual env
+RUN uv init --app kernel-test --python "${PYTHON_VERSION}"
+
+# Move into the app
+WORKDIR /app/kernel-test
+
+# Install PyTorch with the appropriate CUDA version
+
+# NOTE: `markupsafe` must be installed first to avoid a conflict with the torch package. 
+# See: https://github.com/astral-sh/uv/issues/9647
+
+RUN CUDA_MAJOR_MINOR=$(echo ${CUDA_VERSION} | cut -d'.' -f1,2) && \
+    case ${CUDA_MAJOR_MINOR} in \
+    "11.8") CUDA_TAG="cu118" ;; \
+    "12.1") CUDA_TAG="cu121" ;; \
+    "12.2") CUDA_TAG="cu122" ;; \
+    "12.4") CUDA_TAG="cu124" ;; \
+    *) CUDA_TAG="" ;; \
+    esac && \
+    if [ -n "${CUDA_TAG}" ]; then \
+    echo "Installing PyTorch ${TORCH_VERSION} with CUDA ${CUDA_TAG}" && \
+    uv add markupsafe --default-index "https://pypi.org/simple" && \
+    uv add "torch==${TORCH_VERSION}" --index-url "https://download.pytorch.org/whl/${CUDA_TAG}"; \
+    else \
+    echo "Installing PyTorch ${TORCH_VERSION} without CUDA-specific index" && \
+    uv add "torch==${TORCH_VERSION}"; \
+    fi
+
+# add pytest for runtime tests
+RUN uv add numpy pytest
+
+# Copy application files
+COPY kernel ./kernel
+COPY examples/activation/tests ./tests
+
+RUN find .
+
+# Run tests
+ENV PYTHONPATH="kernel:$PYTHONPATH"
+CMD ["/bin/sh", "-c", ".venv/bin/pytest", "tests"] 


### PR DESCRIPTION
This test is to check that the builder works and produces extensions that load on older glibc/libstdc++.