### PR TITLE
Add support for CUTLASS 3.6

### DIFF
--- a/lib/deps.nix
+++ b/lib/deps.nix
@@ -10,8 +10,11 @@
 
 let
   knownDeps = with pkgs.cudaPackages; {
-    "cutlass" = [
-      pkgs.cutlass
+    "cutlass_3_5" = [
+      pkgs.cutlass_3_5
+    ];
+    "cutlass_3_6" = [
+      pkgs.cutlass_3_6
     ];
     "torch" = [
       torch

--- a/overlay.nix
+++ b/overlay.nix
@@ -7,8 +7,6 @@ final: prev: {
     _: prevAttrs: { buildInputs = prevAttrs.buildInputs ++ [ (prev.lib.getLib prev.gfortran.cc) ]; }
   );
 
-  cutlass = prev.callPackage ./pkgs/cutlass { };
-
   cmakeNvccThreadsHook = prev.callPackage ./pkgs/cmake-nvcc-threads-hook { };
 
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
@@ -27,4 +25,4 @@ final: prev: {
   stdenvGlibc_2_27 = prev.callPackage ./pkgs/stdenv-glibc-2_27 { };
 
   toml2cmake = prev.callPackage ./pkgs/toml2cmake { };
-}
+} // (import ./pkgs/cutlass { pkgs = final; })

--- a/pkgs/cutlass/builder.nix
+++ b/pkgs/cutlass/builder.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  cudaPackages,
+  python3,
+}:
+
+{
+  version,
+  hash,
+}:
+
+cudaPackages.backendStdenv.mkDerivation rec {
+  pname = "cutlass";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = pname;
+    rev = "v${version}";
+    inherit hash;
+  };
+
+  nativeBuildInputs =
+    [ cmake ]
+    ++ (with cudaPackages; [
+      setupCudaHook
+      cuda_nvcc
+    ]);
+
+  buildInputs = [ python3 ] ++ (with cudaPackages; [ cuda_cudart ]);
+
+  cmakeFlags = [
+    (lib.cmakeBool "CUTLASS_ENABLE_GTEST_UNIT_TESTS" false)
+    (lib.cmakeBool "CUTLASS_ENABLE_HEADERS_ONLY" true)
+  ];
+
+  meta = {
+    description = "CUDA Templates for Linear Algebra Subroutines";
+    homepage = "https://github.com/NVIDIA/cutlass";
+    license = lib.licenses.bsd3;
+  };
+}

--- a/pkgs/cutlass/default.nix
+++ b/pkgs/cutlass/default.nix
@@ -1,39 +1,15 @@
-{
-  lib,
-  fetchFromGitHub,
-  cmake,
-  cudaPackages,
-  python3,
-}:
+{ pkgs }:
 
-cudaPackages.backendStdenv.mkDerivation rec {
-  pname = "cutlass";
-  version = "3.5.1";
-
-  src = fetchFromGitHub {
-    owner = "NVIDIA";
-    repo = pname;
-    rev = "v${version}";
+let
+  builder = pkgs.callPackage ./builder.nix {};
+in {
+  cutlass_3_5 = builder {
+    version = "3.5.1";
     hash = "sha256-sTGYN+bjtEqQ7Ootr/wvx3P9f8MCDSSj3qyCWjfdLEA=";
   };
 
-  nativeBuildInputs =
-    [ cmake ]
-    ++ (with cudaPackages; [
-      setupCudaHook
-      cuda_nvcc
-    ]);
-
-  buildInputs = [ python3 ] ++ (with cudaPackages; [ cuda_cudart ]);
-
-  cmakeFlags = [
-    (lib.cmakeBool "CUTLASS_ENABLE_GTEST_UNIT_TESTS" false)
-    (lib.cmakeBool "CUTLASS_ENABLE_HEADERS_ONLY" true)
-  ];
-
-  meta = {
-    description = "CUDA Templates for Linear Algebra Subroutines";
-    homepage = "https://github.com/NVIDIA/cutlass";
-    license = lib.licenses.bsd3;
+  cutlass_3_6 = builder {
+    version = "3.6.0";
+    hash = "sha256-FbMVqR4eZyum5w4Dj5qJgBPOS66sTem/qKZjYIK/7sg=";
   };
 }

--- a/toml2cmake/src/config.rs
+++ b/toml2cmake/src/config.rs
@@ -43,6 +43,9 @@ pub struct Kernel {
 #[non_exhaustive]
 #[serde(rename_all = "lowercase")]
 pub enum Dependencies {
-    Cutlass,
+    #[serde[rename = "cutlass_3_5"]]
+    Cutlass35,
+    #[serde[rename = "cutlass_3_6"]]
+    Cutlass36,
     Torch,
 }

--- a/toml2cmake/src/templates/dep-cutlass.cmake
+++ b/toml2cmake/src/templates/dep-cutlass.cmake
@@ -4,7 +4,7 @@ if (NOT NvidiaCutlass_FOUND)
   set(CUTLASS_ENABLE_HEADERS_ONLY ON CACHE BOOL "Enable only the header library")
 
 # Set CUTLASS_REVISION manually -- its revision detection doesn't work in this case.
-  set(CUTLASS_REVISION "v3.5.1" CACHE STRING "CUTLASS revision to use")
+  set(CUTLASS_REVISION "v{{ version }}" CACHE STRING "CUTLASS revision to use")
 
 
 # Use the specified CUTLASS source directory for compilation if CUTLASS_SRC_DIR is provided
@@ -22,7 +22,7 @@ if (NOT NvidiaCutlass_FOUND)
     FetchContent_Declare(
         cutlass
         GIT_REPOSITORY https://github.com/nvidia/cutlass.git
-        GIT_TAG v3.5.1
+        GIT_TAG v{{ version }}
         GIT_PROGRESS TRUE
 
         # Speed up CUTLASS download by retrieving only the specified GIT_TAG instead of the history.

--- a/toml2cmake/src/torch.rs
+++ b/toml2cmake/src/torch.rs
@@ -155,10 +155,26 @@ fn render_deps(env: &Environment, build: &Build, write: &mut impl Write) -> Resu
 
     for dep in deps {
         match dep {
-            Dependencies::Cutlass => {
+            Dependencies::Cutlass35 => {
                 env.get_template("dep-cutlass.cmake")
                     .wrap_err("Cannot get CUTLASS dependency template")?
-                    .render_to_write(context! {}, &mut *write)
+                    .render_to_write(
+                        context! {
+                            version => "3.5.1",
+                        },
+                        &mut *write,
+                    )
+                    .wrap_err("Cannot render CUTLASS dependency template")?;
+            }
+            Dependencies::Cutlass36 => {
+                env.get_template("dep-cutlass.cmake")
+                    .wrap_err("Cannot get CUTLASS dependency template")?
+                    .render_to_write(
+                        context! {
+                            version => "3.6.0",
+                        },
+                        &mut *write,
+                    )
                     .wrap_err("Cannot render CUTLASS dependency template")?;
             }
             Dependencies::Torch => (),


### PR DESCRIPTION
Since CUTLASS is not guaranteed to be API compatible between minor versions, add the version to the dependency.