### PR TITLE
Small fixes for building wheels

### DIFF
--- a/toml2cmake/src/config.rs
+++ b/toml2cmake/src/config.rs
@@ -23,9 +23,7 @@ pub struct General {
 pub struct Torch {
     pub name: String,
     pub include: Option<Vec<String>>,
-    // Used by the builder, so we have to accept this field.
-    #[serde(rename = "pyext")]
-    pub _pyext: Option<Vec<String>>,
+    pub pyext: Option<Vec<String>>,
     pub pyroot: PathBuf,
     pub src: Vec<PathBuf>,
 }

--- a/toml2cmake/src/main.rs
+++ b/toml2cmake/src/main.rs
@@ -73,6 +73,7 @@ fn generate_torch(build_toml: PathBuf, target_dir: Option<PathBuf>, force: bool)
         .wrap_err_with(|| format!("Cannot parse TOML in {}", build_toml.to_string_lossy()))?;
 
     let mut env = Environment::new();
+    env.set_trim_blocks(true);
     minijinja_embed::load_templates!(&mut env);
 
     write_torch_ext(&env, &build, target_dir, force)?;

--- a/toml2cmake/src/templates/setup.py
+++ b/toml2cmake/src/templates/setup.py
@@ -123,6 +123,9 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     packages=find_packages(where="torch-ext", include=["{{ name }}*"]),
     package_dir={"": "{{ pyroot }}"},
+{% if data_globs %}
+    package_data={"{{ name }}": [ {{ data_globs }} ]},
+{% endif %}
     zip_safe=False,
     install_requires=["torch"],
     python_requires=">=3.9",

--- a/toml2cmake/src/templates/setup.py
+++ b/toml2cmake/src/templates/setup.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from setuptools import Extension, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 logger = logging.getLogger(__name__)
@@ -121,8 +121,8 @@ setup(
     version="{{ version }}",
     ext_modules=[CMakeExtension("{{ name }}.{{ ops_name }}")],
     cmdclass={"build_ext": CMakeBuild},
-    packages=["{{ name }}"],
-    package_dir={"{{ name }}": "{{ pyroot }}/{{ name }}"},
+    packages=find_packages(where="torch-ext", include=["{{ name }}*"]),
+    package_dir={"": "{{ pyroot }}"},
     zip_safe=False,
     install_requires=["torch"],
     python_requires=">=3.9",

--- a/toml2cmake/src/torch.rs
+++ b/toml2cmake/src/torch.rs
@@ -77,10 +77,29 @@ fn write_setup_py(
 ) -> Result<()> {
     let writer = file_set.entry("setup.py");
 
+    // Globs for files that are not Python files.
+    let data_globs = match torch.pyext.as_ref() {
+        Some(exts) => {
+            let globs = exts
+                .iter()
+                .filter(|&ext| ext != "py" && ext != "pyi")
+                .map(|ext| format!("\"**/*.{}\"", ext))
+                .collect_vec();
+            if globs.is_empty() {
+                None
+            } else {
+                Some(globs.join(", "))
+            }
+        }
+
+        None => None,
+    };
+
     env.get_template("setup.py")
         .wrap_err("Cannot get setup.py template")?
         .render_to_write(
             context! {
+                data_globs => data_globs,
                 ops_name => ops_name,
                 name => torch.name,
                 version => version,


### PR DESCRIPTION
This change makes some small fixes for building wheels:

* Ensure that subpackages are included.
* Use `pysrc` for adding data files to the wheel (e.g. Triton configurations).
* Trim blocks in minijinja for cleaner output.

We currently only build wheels in the `tgi-nix` overlay.