### PR TITLE
toml2cmake: pass `pyroot` to `find_packages`

### DIFF
--- a/toml2cmake/src/templates/setup.py
+++ b/toml2cmake/src/templates/setup.py
@@ -121,7 +121,7 @@ setup(
     version="{{ version }}",
     ext_modules=[CMakeExtension("{{ name }}.{{ ops_name }}")],
     cmdclass={"build_ext": CMakeBuild},
-    packages=find_packages(where="torch-ext", include=["{{ name }}*"]),
+    packages=find_packages(where="{{ pyroot }}", include=["{{ name }}*"]),
     package_dir={"": "{{ pyroot }}"},
 {% if data_globs %}
     package_data={"{{ name }}": [ {{ data_globs }} ]},


### PR DESCRIPTION
Hotfix to pass the correct path.