### PR TITLE
fix: copy build contents and adjust permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,10 @@ COPY . /etc/kernel-builder/
 
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CORES=${CORES}
-ENTRYPOINT ["/bin/sh", "-c", "nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L"]
+ENTRYPOINT ["/bin/sh", "-c", "\
+    nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L && \
+    rm -rf /kernelcode/result && mkdir -p /kernelcode/result && \
+    cp -r --dereference ./result/* /kernelcode/result/ && \
+    chmod -R 777 /kernelcode/result && \
+    echo 'Build completed. Results copied to /kernelcode/result/'\
+"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV MAX_JOBS=${MAX_JOBS}
 ENV CORES=${CORES}
 ENTRYPOINT ["/bin/sh", "-c", "\
     nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L && \
-    rm -rf /kernelcode/result && mkdir -p /kernelcode/result && \
-    cp -r --dereference ./result/* /kernelcode/result/ && \
-    chmod -R 777 /kernelcode/result && \
-    echo 'Build completed. Results copied to /kernelcode/result/'\
+    mkdir -p /kernelcode/build-output && \
+    cp -r --dereference ./result/* /kernelcode/build-output/ && \
+    chmod -R 777 /kernelcode/build-output && \
+    echo 'Build completed. Results copied to /kernelcode/build-output/'\
 "]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ ENTRYPOINT ["/bin/sh", "-c", "\
     nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L && \
     mkdir -p /kernelcode/build-output && \
     cp -r --dereference ./result/* /kernelcode/build-output/ && \
-    chmod -R 777 /kernelcode/build-output && \
+    chmod -R u+w /kernelcode/build-output && \
     echo 'Build completed. Results copied to /kernelcode/build-output/'\
 "]


### PR DESCRIPTION
This PR improves the Dockerfile to copy the build outputs contents into a `build-output` folder instead of copying symlink. Additionally the build output's permissions are adjust to allow the host to have full permission.