### PR TITLE
Add support for ROCm to build2cmake and extension derivation

### DIFF
--- a/build2cmake/src/cmake/hipify.py
+++ b/build2cmake/src/cmake/hipify.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# A command line tool for running pytorch's hipify preprocessor on CUDA
+# source files.
+#
+# See https://github.com/ROCm/hipify_torch
+# and <torch install dir>/utils/hipify/hipify_python.py
+#
+
+import argparse
+import os
+import shutil
+
+from torch.utils.hipify.hipify_python import hipify
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    # Project directory where all the source + include files live.
+    parser.add_argument(
+        "-p",
+        "--project_dir",
+        help="The project directory.",
+    )
+
+    # Directory where hipified files are written.
+    parser.add_argument(
+        "-o",
+        "--output_dir",
+        help="The output directory.",
+    )
+
+    # Source files to convert.
+    parser.add_argument("sources",
+                        help="Source files to hipify.",
+                        nargs="*",
+                        default=[])
+
+    args = parser.parse_args()
+
+    # Limit include scope to project_dir only
+    includes = [os.path.join(args.project_dir, '*')]
+
+    # Get absolute path for all source files.
+    extra_files = [os.path.abspath(s) for s in args.sources]
+
+    # Copy sources from project directory to output directory.
+    # The directory might already exist to hold object files so we ignore that.
+    shutil.copytree(args.project_dir, args.output_dir, dirs_exist_ok=True)
+
+    hipify_result = hipify(project_directory=args.project_dir,
+                           output_directory=args.output_dir,
+                           header_include_dirs=[],
+                           includes=includes,
+                           extra_files=extra_files,
+                           show_detailed=True,
+                           is_pytorch_extension=True,
+                           hipify_extra_files_only=True)
+
+    hipified_sources = []
+    for source in args.sources:
+        s_abs = os.path.abspath(source)
+        hipified_s_abs = (hipify_result[s_abs].hipified_path if
+                          (s_abs in hipify_result
+                           and hipify_result[s_abs].hipified_path is not None)
+                          else s_abs)
+        hipified_sources.append(hipified_s_abs)
+
+    assert (len(hipified_sources) == len(args.sources))
+
+    # Print hipified source files.
+    print("\n".join(hipified_sources))

--- a/build2cmake/src/cmake/hipify.py
+++ b/build2cmake/src/cmake/hipify.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
 
+# From vLLM: https://github.com/vllm-project/vllm/blob/main/cmake/hipify.py
+
 #
 # A command line tool for running pytorch's hipify preprocessor on CUDA
 # source files.

--- a/build2cmake/src/config.rs
+++ b/build2cmake/src/config.rs
@@ -30,6 +30,7 @@ pub struct Torch {
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct Kernel {
     pub cuda_capabilities: Vec<String>,
+    pub rocm_archs: Option<Vec<String>>,
     pub depends: Vec<Dependencies>,
     pub include: Option<Vec<String>>,
     pub src: Vec<String>,

--- a/build2cmake/src/templates/kernel.cmake
+++ b/build2cmake/src/templates/kernel.cmake
@@ -10,7 +10,15 @@ set_source_files_properties(
   PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
 {% endif %}
 
-cuda_archs_loose_intersection({{kernel_name}}_ARCHS "{{ cuda_capabilities|join(";") }}" ${CUDA_ARCHS})
-set_gencode_flags_for_srcs(SRCS {{'"${' + kernel_name + '_SRC}"'}} CUDA_ARCHS {{ '${' + kernel_name + '_ARCHS}'}})
+if(GPU_LANG STREQUAL "CUDA")
+  cuda_archs_loose_intersection({{kernel_name}}_ARCHS "{{ cuda_capabilities|join(";") }}" ${CUDA_ARCHS})
+  set_gencode_flags_for_srcs(SRCS {{'"${' + kernel_name + '_SRC}"'}} CUDA_ARCHS {{ '${' + kernel_name + '_ARCHS}'}})
+  list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})
+{% if rocm_archs %}
+elseif(GPU_LANG STREQUAL "HIP")
+  # We currently don't use the archs yet.
+  # set({{kernel_name}}_ARCHS "{{ rocm_archs|join(";") }}")
+  list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})
+{% endif %}
+endif()
 
-list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})

--- a/build2cmake/src/templates/torch-extension.cmake
+++ b/build2cmake/src/templates/torch-extension.cmake
@@ -1,7 +1,5 @@
-get_torch_gpu_compiler_flags(TORCH_GPU_FLAGS ${GPU_LANGUAGE})
+get_torch_gpu_compiler_flags(GPU_FLAGS ${GPU_LANG})
 list(APPEND GPU_FLAGS ${TORCH_GPU_FLAGS})
-
-
 
 set(TORCH_{{name}}_SRC
   {{ src|join(' ') }}
@@ -20,10 +18,10 @@ list(APPEND SRC {{'"${TORCH_' + name + '_SRC}"'}})
 define_gpu_extension_target(
   {{ ops_name }}
   DESTINATION {{ ops_name }}
-  LANGUAGE ${GPU_LANGUAGE}
+  LANGUAGE ${GPU_LANG}
   SOURCES ${SRC}
   COMPILE_FLAGS ${GPU_FLAGS}
-  ARCHITECTURES ${GPU_ARCHITECTURES}
+  ARCHITECTURES ${GPU_ARCHES}
   #INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
   USE_SABI 3
   WITH_SOABI)

--- a/build2cmake/src/torch.rs
+++ b/build2cmake/src/torch.rs
@@ -12,6 +12,7 @@ use crate::FileSet;
 
 static CMAKE_UTILS: &str = include_str!("cmake/utils.cmake");
 static REGISTRATION_H: &str = include_str!("templates/registration.h");
+static HIPIFY: &str = include_str!("cmake/hipify.py");
 
 fn kernel_ops_identifier(name: &str) -> String {
     let mut rng = rand::thread_rng();
@@ -172,6 +173,13 @@ fn write_cmake(
         .entry(utils_path.clone())
         .extend_from_slice(CMAKE_UTILS.as_bytes());
 
+    let mut hipify_path = PathBuf::new();
+    hipify_path.push("cmake");
+    hipify_path.push("hipify.py");
+    file_set
+        .entry(hipify_path.clone())
+        .extend_from_slice(HIPIFY.as_bytes());
+
     let cmake_writer = file_set.entry("CMakeLists.txt");
 
     render_preamble(env, name, cmake_writer)?;
@@ -255,6 +263,7 @@ pub fn render_kernel(
         .render_to_write(
             context! {
                 cuda_capabilities => kernel.cuda_capabilities,
+                rocm_archs => kernel.rocm_archs,
                 includes => kernel.include.as_ref().map(prefix_and_join_includes),
                 kernel_name => kernel_name,
                 sources => sources,

--- a/flake.nix
+++ b/flake.nix
@@ -35,16 +35,9 @@
 
       libPerSystem = builtins.mapAttrs (
         system: buildSet:
-        let
-          # Remove this later, temporary workaround until the CMake bits
-          # support ROCm.
-          buildSets = builtins.filter (
-            buildSet: buildSet.pkgs.config.cudaSupport
-          ) buildSetPerSystem.${system};
-        in
         import lib/build.nix {
-          inherit buildSets;
           inherit (nixpkgs) lib;
+          buildSets = buildSetPerSystem.${system};
         }
       ) buildSetPerSystem;
 

--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -7,20 +7,25 @@
 
   src,
 
+  config,
+  cudaSupport ? config.cudaSupport,
+  rocmSupport ? config.rocmSupport,
+
   lib,
-  stdenv ? cudaPackages.backendStdenv,
+  stdenv,
   cudaPackages,
   cmake,
   cmakeNvccThreadsHook,
   ninja,
   python3,
   build2cmake,
+  rocmPackages,
 
   extraDeps ? [ ],
   torch,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (prevAttrs: {
   name = "${extensionName}-torch-ext";
 
   inherit nvccThreads src;
@@ -30,43 +35,70 @@ stdenv.mkDerivation {
     build2cmake generate-torch build.toml
   '';
 
-  nativeBuildInputs = [
-    cmake
-    cmakeNvccThreadsHook
-    ninja
-    cudaPackages.cuda_nvcc
-    build2cmake
-  ];
+  # hipify copies files, but its target is run in the CMake build and install
+  # phases. Since some of the files come from the Nix store, this fails the
+  # second time around.
+  preInstall = ''
+    chmod -R u+w .
+  '';
+
+  nativeBuildInputs =
+    [
+      cmake
+      ninja
+      build2cmake
+    ]
+    ++ lib.optionals cudaSupport [
+      cmakeNvccThreadsHook
+      cudaPackages.cuda_nvcc
+    ]
+    ++ lib.optionals rocmSupport [
+      rocmPackages.clr
+    ];
 
   buildInputs =
     [
       torch
       torch.cxxdev
     ]
-    ++ (with cudaPackages; [
-      cuda_cudart
+    ++ lib.optionals cudaSupport (
+      with cudaPackages;
+      [
+        cuda_cudart
 
-      # Make dependent on build configuration dependencies once
-      # the Torch dependency is gone.
-      cuda_cccl
-      libcublas
-      libcusolver
-      libcusparse
-    ])
+        # Make dependent on build configuration dependencies once
+        # the Torch dependency is gone.
+        cuda_cccl
+        libcublas
+        libcusolver
+        libcusparse
+      ]
+    )
+    #++ lib.optionals rocmSupport (with rocmPackages; [ clr rocm-core ])
     ++ extraDeps;
 
-  env = {
-    CUDAToolkit_ROOT = "${lib.getDev cudaPackages.cuda_nvcc}";
-    TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
-  };
+  env =
+    lib.optionalAttrs cudaSupport {
+      CUDAToolkit_ROOT = "${lib.getDev cudaPackages.cuda_nvcc}";
+      TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" torch.cudaCapabilities;
+    }
+    // lib.optionalAttrs rocmSupport {
+      PYTORCH_ROCM_ARCH = lib.concatStringsSep ";" torch.rocmArchs;
+    };
 
   # If we use the default setup, CMAKE_CUDA_HOST_COMPILER gets set to nixpkgs g++.
   dontSetupCUDAToolkitCompilers = true;
 
-  cmakeFlags = [
-    (lib.cmakeFeature "CMAKE_CUDA_HOST_COMPILER" "${stdenv.cc}/bin/g++")
-    (lib.cmakeFeature "Python_EXECUTABLE" "${python3.withPackages (ps: [ torch ])}/bin/python")
-  ];
+  cmakeFlags =
+    [
+      (lib.cmakeFeature "Python_EXECUTABLE" "${python3.withPackages (ps: [ torch ])}/bin/python")
+    ]
+    ++ lib.optionals cudaSupport [
+      (lib.cmakeFeature "CMAKE_CUDA_HOST_COMPILER" "${stdenv.cc}/bin/g++")
+    ]
+    ++ lib.optionals rocmSupport [
+      (lib.cmakeFeature "CMAKE_HIP_COMPILER_ROCM_ROOT" "${rocmPackages.clr}")
+    ];
 
   postInstall =
     ''
@@ -85,4 +117,4 @@ stdenv.mkDerivation {
   passthru = {
     inherit torch;
   };
-}
+})

--- a/pkgs/stdenv-glibc-2_27/default.nix
+++ b/pkgs/stdenv-glibc-2_27/default.nix
@@ -1,9 +1,12 @@
 {
+  config,
+  cudaSupport ? config.cudaSupport,
   fetchFromGitHub,
   overrideCC,
   system,
   wrapBintoolsWith,
   wrapCCWith,
+  gcc12Stdenv,
   stdenv,
   bintools-unwrapped,
   cudaPackages,
@@ -69,4 +72,4 @@ let
     overrideCC stdenv compilerWrapped;
 
 in
-stdenvWith glibc_2_27 cudaPackages.backendStdenv.cc.cc stdenv
+stdenvWith glibc_2_27 (if cudaSupport then cudaPackages.backendStdenv else gcc12Stdenv).cc.cc stdenv


### PR DESCRIPTION
With this change we can successfully build ROCm Torch extensions (tested with the quantization kernel). The resulting extension probably doesn't work yet until we downgrade ROCm to match PyTorch.