### PR TITLE
python3Packages.torch_2_{5,6}: make support latest rocm-nix changes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741097349,
-        "narHash": "sha256-aBa7X3/Iv4ionu6eUd8DFfP+QFB9124tAGxRz/Vwni4=",
+        "lastModified": 1742285724,
+        "narHash": "sha256-2QQn9fzmF/SKW082kXpSrEBgfmwKO2RNT5R91Fn/K4M=",
         "owner": "huggingface",
         "repo": "rocm-nix",
-        "rev": "f9f8fd7f7c2571cccc1a3bb3e2971adf98ed5bea",
+        "rev": "a90de1c2e5698b2f4fe984b5f0faf052f466be49",
         "type": "github"
       },
       "original": {

--- a/pkgs/python-modules/torch_2_5/default.nix
+++ b/pkgs/python-modules/torch_2_5/default.nix
@@ -67,7 +67,7 @@
     if cudaSupport then
       triton-cuda
     else if rocmSupport then
-      rocmPackages.aotriton
+      rocmPackages.aotriton_0_8
     else
       triton,
   triton-cuda,
@@ -449,7 +449,7 @@ buildPythonPackage rec {
       );
     }
     // lib.optionalAttrs rocmSupport {
-      AOTRITON_INSTALLED_PREFIX = rocmPackages.aotriton;
+      AOTRITON_INSTALLED_PREFIX = rocmPackages.aotriton_0_8;
     };
 
   nativeBuildInputs =

--- a/pkgs/python-modules/torch_2_6/default.nix
+++ b/pkgs/python-modules/torch_2_6/default.nix
@@ -67,7 +67,7 @@
     if cudaSupport then
       triton-cuda
     else if rocmSupport then
-      rocmPackages.aotriton
+      rocmPackages.aotriton_0_8
     else
       triton,
   triton-cuda,
@@ -449,7 +449,7 @@ buildPythonPackage rec {
       );
     }
     // lib.optionalAttrs rocmSupport {
-      AOTRITON_INSTALLED_PREFIX = rocmPackages.aotriton;
+      AOTRITON_INSTALLED_PREFIX = rocmPackages.aotriton_0_8;
     };
 
   nativeBuildInputs =


### PR DESCRIPTION
`aotriton` is now named `aotriton_0_8`.