### PR TITLE
Add `language` option for kernels

### DIFF
--- a/build2cmake/src/config.rs
+++ b/build2cmake/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fmt::Display, path::PathBuf};
 
 use itertools::Itertools;
 use serde::Deserialize;
@@ -58,9 +58,28 @@ impl Torch {
 pub struct Kernel {
     pub cuda_capabilities: Vec<String>,
     pub rocm_archs: Option<Vec<String>>,
+    #[serde(default)]
+    pub language: Language,
     pub depends: Vec<Dependencies>,
     pub include: Option<Vec<String>>,
     pub src: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub enum Language {
+    #[default]
+    Cuda,
+    CudaHipify,
+}
+
+impl Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Language::Cuda => f.write_str("cuda"),
+            Language::CudaHipify => f.write_str("cuda-hipify"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq)]

--- a/build2cmake/src/templates/kernel.cmake
+++ b/build2cmake/src/templates/kernel.cmake
@@ -14,7 +14,7 @@ if(GPU_LANG STREQUAL "CUDA")
   cuda_archs_loose_intersection({{kernel_name}}_ARCHS "{{ cuda_capabilities|join(";") }}" ${CUDA_ARCHS})
   set_gencode_flags_for_srcs(SRCS {{'"${' + kernel_name + '_SRC}"'}} CUDA_ARCHS {{ '${' + kernel_name + '_ARCHS}'}})
   list(APPEND SRC {{'"${' + kernel_name + '_SRC}"'}})
-{% if rocm_archs %}
+{% if language == "cuda-hipify" %}
 elseif(GPU_LANG STREQUAL "HIP")
   # We currently don't use the archs yet.
   # set({{kernel_name}}_ARCHS "{{ rocm_archs|join(";") }}")

--- a/build2cmake/src/torch.rs
+++ b/build2cmake/src/torch.rs
@@ -250,6 +250,7 @@ pub fn render_kernel(
                 rocm_archs => kernel.rocm_archs,
                 includes => kernel.include.as_ref().map(prefix_and_join_includes),
                 kernel_name => kernel_name,
+                language => kernel.language.to_string(),
                 sources => sources,
             },
             &mut *write,

--- a/docs/writing-kernels.md
+++ b/docs/writing-kernels.md
@@ -109,11 +109,18 @@ the following options:
 
 - `cuda-capabilities` (required): a list of CUDA capabilities that the
   kernel should be compiled for.
+- `rocm-archs` (required): a list of ROCm architectures that the kernel
+  should be compiled for.
 - `depends` (required): a list of dependencies. The supported dependencies
   are listed in [`deps.nix`](../lib/deps.nix].
 - `src` (required): a list of source files and headers.
 - `include` (optional): include directories relative to the project root.
   Default: `[]`.
+- `language` (optional): the language used for the kernel. Must be `cuda`
+  or `cuda-hipify`. `cuda-hipify` is for CUDA kernels that can also be
+  compiled for ROCm using hipify. **Warning:** `cuda-hipify` is currently
+  experimental and does not produce conforming kernels yet.
+  Default: `"cuda"`
 
 Multiple `kernel.<name>` sections can be defined in the same `build.toml`.
 See for example [`kernels-community/quantization`](https://huggingface.co/kernels-community/quantization/)

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -1,4 +1,8 @@
-{ pkgs, torch }:
+{
+  gpu,
+  pkgs,
+  torch,
+}:
 let
   inherit (pkgs) lib;
   flattenVersion = version: lib.replaceStrings [ "." ] [ "" ] (lib.versions.pad 2 version);

--- a/lib/buildsets.nix
+++ b/lib/buildsets.nix
@@ -35,7 +35,7 @@ let
       };
     in
     {
-      inherit pkgs torch;
+      inherit gpu pkgs torch;
     };
 
   pkgsForRocm = import nixpkgs {


### PR DESCRIPTION
This option can currently be `cuda` (CUDA) or `cuda-hipify` (CUDA that can also be compiled on ROCm using hipify). The default is `cuda`.

The kernel `language`s is used to determine for what Torch versions a kernel should be compiled.