### PR TITLE
feat: add snapshot e2e test for build2cmake

### DIFF
--- a/build2cmake/Cargo.lock
+++ b/build2cmake/Cargo.lock
@@ -58,17 +58,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "build2cmake"
 version = "0.1.0"
 dependencies = [
  "base32",
  "clap",
  "eyre",
+ "insta",
  "itertools",
  "minijinja",
  "minijinja-embed",
  "rand",
  "serde",
+ "tempfile",
  "toml",
 ]
 
@@ -131,16 +139,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "eyre"
@@ -153,6 +189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,7 +202,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -192,6 +246,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50259abbaa67d11d2bcafc7ba1d094ed7a0c70e3ce893f0d0997f73558cb3084"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pin-project",
+ "similar",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +278,18 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "memchr"
@@ -240,6 +319,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +364,12 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -293,7 +398,20 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -326,6 +444,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +464,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -393,6 +530,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "windows-sys"
@@ -474,6 +620,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/build2cmake/Cargo.toml
+++ b/build2cmake/Cargo.toml
@@ -12,11 +12,13 @@ repository = "https://github.com/huggingface/kernel-builder"
 base32 = "0.5"
 clap = { version = "4", features = ["derive"] }
 eyre = "0.6.12"
+insta = "1.42.2"
 itertools = "0.13"
 minijinja = "2.5"
 minijinja-embed = "2.5"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+tempfile = "3.19.1"
 toml = "0.8"
 
 [build-dependencies]

--- a/build2cmake/src/e2e_test.rs
+++ b/build2cmake/src/e2e_test.rs
@@ -1,0 +1,62 @@
+use insta::assert_snapshot;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::Path;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_generate_torch_command() -> Result<(), Box<dyn std::error::Error>> {
+    // Setup test environment
+    let temp_dir = tempdir()?;
+    let temp_path = temp_dir.path();
+    fs::copy("../examples/relu/build.toml", temp_path.join("build.toml"))?;
+
+    // Run CLI command
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "generate-torch",
+            &temp_path.join("build.toml").to_string_lossy(),
+            "--ops-id",
+            "test_ops_id",
+            "--force",
+        ])
+        .output()?;
+
+    // Check success
+    assert!(
+        output.status.success(),
+        "Command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Test generated CMakeLists.txt
+    let cmake_path = temp_path.join("CMakeLists.txt");
+    assert!(cmake_path.exists(), "CMakeLists.txt not generated");
+    assert_snapshot!("cmake_lists", read_and_normalize(&cmake_path)?);
+
+    // Test all generated C++ files
+    for entry in fs::read_dir(temp_path)?.filter_map(Result::ok) {
+        let path = entry.path();
+        if has_extension(&path, &["cpp", "h"]) {
+            let filename = path.file_name().unwrap().to_string_lossy();
+            assert_snapshot!(format!("file_{}", filename), read_and_normalize(&path)?);
+        }
+    }
+
+    Ok(())
+}
+
+// Helper functions
+fn read_and_normalize(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let mut content = String::new();
+    File::open(path)?.read_to_string(&mut content)?;
+    Ok(content.replace("\r\n", "\n").trim().to_string())
+}
+
+fn has_extension(path: &Path, exts: &[&str]) -> bool {
+    path.extension()
+        .map_or(false, |ext| exts.contains(&ext.to_string_lossy().as_ref()))
+}

--- a/build2cmake/src/main.rs
+++ b/build2cmake/src/main.rs
@@ -20,6 +20,9 @@ mod fileset;
 use fileset::FileSet;
 use torch_universal::write_torch_universal_ext;
 
+#[cfg(test)]
+mod e2e_test;
+
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Cli {

--- a/build2cmake/src/snapshots/build2cmake__e2e_test__cmake_lists.snap
+++ b/build2cmake/src/snapshots/build2cmake__e2e_test__cmake_lists.snap
@@ -1,0 +1,105 @@
+---
+source: src/e2e_test.rs
+expression: normalize_for_snapshot(&cmake_content)
+---
+cmake_minimum_required(VERSION 3.26)
+project(relu LANGUAGES CXX)
+
+set(TARGET_DEVICE "cuda" CACHE STRING "Target device backend for kernel")
+
+install(CODE "set(CMAKE_INSTALL_LOCAL_ONLY TRUE)" ALL_COMPONENTS)
+
+include(FetchContent)
+file(MAKE_DIRECTORY ${FETCHCONTENT_BASE_DIR}) # Ensure the directory exists
+message(STATUS "FetchContent base directory: ${FETCHCONTENT_BASE_DIR}")
+
+set(CUDA_SUPPORTED_ARCHS "7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0")
+
+set(HIP_SUPPORTED_ARCHS "gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101")
+
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)
+
+if(DEFINED Python_EXECUTABLE)
+  # Allow passing through the interpreter (e.g. from setup.py).
+  find_package(Python COMPONENTS Development Development.SABIModule Interpreter)
+  if (NOT Python_FOUND)
+    message(FATAL_ERROR "Unable to find python matching: ${EXECUTABLE}.")
+  endif()
+else()
+  find_package(Python REQUIRED COMPONENTS Development Development.SABIModule Interpreter)
+endif()
+
+append_cmake_prefix_path("torch" "torch.utils.cmake_prefix_path")
+
+find_package(Torch REQUIRED)
+
+if (NOT TARGET_DEVICE STREQUAL "cuda" AND
+    NOT TARGET_DEVICE STREQUAL "rocm")
+    return()
+endif()
+
+if (NOT HIP_FOUND AND CUDA_FOUND)
+  set(GPU_LANG "CUDA")
+elseif(HIP_FOUND)
+  set(GPU_LANG "HIP")
+
+  # Importing torch recognizes and sets up some HIP/ROCm configuration but does
+  # not let cmake recognize .hip files. In order to get cmake to understand the
+  # .hip extension automatically, HIP must be enabled explicitly.
+  enable_language(HIP)
+else()
+  message(FATAL_ERROR "Can't find CUDA or HIP installation.")
+endif()
+
+
+if(GPU_LANG STREQUAL "CUDA")
+  clear_cuda_arches(CUDA_ARCH_FLAGS)
+  extract_unique_cuda_archs_ascending(CUDA_ARCHS "${CUDA_ARCH_FLAGS}")
+  message(STATUS "CUDA target architectures: ${CUDA_ARCHS}")
+  # Filter the target architectures by the supported supported archs
+  # since for some files we will build for all CUDA_ARCHS.
+  cuda_archs_loose_intersection(CUDA_ARCHS "${CUDA_SUPPORTED_ARCHS}" "${CUDA_ARCHS}")
+  message(STATUS "CUDA supported target architectures: ${CUDA_ARCHS}")
+
+  if(NVCC_THREADS AND GPU_LANG STREQUAL "CUDA")
+    list(APPEND GPU_FLAGS "--threads=${NVCC_THREADS}")
+  endif()
+else()
+  override_gpu_arches(GPU_ARCHES
+    ${GPU_LANG}
+    "${${GPU_LANG}_SUPPORTED_ARCHS}")
+endif()
+
+set(activation_SRC
+  "relu_kernel/relu.cu"
+)
+
+
+if(GPU_LANG STREQUAL "CUDA")
+  cuda_archs_loose_intersection(activation_ARCHS "7.0;7.2;7.5;8.0;8.6;8.7;8.9;9.0" ${CUDA_ARCHS})
+  set_gencode_flags_for_srcs(SRCS "${activation_SRC}" CUDA_ARCHS ${activation_ARCHS})
+  list(APPEND SRC "${activation_SRC}")
+endif()
+
+get_torch_gpu_compiler_flags(GPU_FLAGS ${GPU_LANG})
+list(APPEND GPU_FLAGS ${TORCH_GPU_FLAGS})
+
+set(TORCH_relu_SRC
+  torch-ext/torch_binding.cpp torch-ext/torch_binding.h
+)
+
+
+list(APPEND SRC "${TORCH_relu_SRC}")
+
+define_gpu_extension_target(
+  _relu_test_ops_id
+  DESTINATION _relu_test_ops_id
+  LANGUAGE ${GPU_LANG}
+  SOURCES ${SRC}
+  COMPILE_FLAGS ${GPU_FLAGS}
+  ARCHITECTURES ${GPU_ARCHES}
+  #INCLUDE_DIRECTORIES ${CUTLASS_INCLUDE_DIR}
+  USE_SABI 3
+  WITH_SOABI)
+
+target_link_options(_relu_test_ops_id PRIVATE -static-libstdc++)


### PR DESCRIPTION
This PR adds a small e2e test with a snapshot for the `build2cmake` tool. This aims to improve insight into the generated cmake file and avoid regressions in the future