### PR TITLE
Make default devshell system-generic

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
             in
             {
               devShells = rec {
-                default = shells.torch26-cxx98-cu126-x86_64-linux;
+                default = shells."torch26-cxx98-cu126-${system}";
                 shells = build.torchExtensionShells {
                   inherit path;
                   rev = revUnderscored;


### PR DESCRIPTION
This makes the devshell work on AArch64.