### PR TITLE
fix: pass rev from repo into build command in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM nixos/nix:2.18.8
 # default build args
 ARG MAX_JOBS=4
 ARG CORES=4
-ARG REV="unknown"
 
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && echo "max-jobs = $MAX_JOBS" >> /etc/nix/nix.conf \
@@ -16,18 +15,36 @@ COPY . /etc/kernel-builder/
 
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CORES=${CORES}
-ENV REV=${REV}
 
 RUN mkdir -p /etc/kernelcode && \
     cat <<'EOF' > /etc/kernelcode/entry.sh
 #!/bin/sh
 echo "Building Torch Extension Bundle"
 
+# Check if kernelcode is a git repo and get hash if possible
+if [ -d "/kernelcode/.git" ]; then
+  # Mark git as safe to allow commands
+  git config --global --add safe.directory /kernelcode
+
+  # Try to get git revision
+  REV=$(git rev-parse --short=8 HEAD)
+  
+  # Check if working directory is dirty
+  if [ -n "$(git status --porcelain 2)" ]; then
+    REV="${REV}-dirty"
+  fi
+else
+  # Generate random material if not a git repo
+  REV=$(dd if=/dev/urandom status=none bs=1 count=10 2>/dev/null | base32 | tr '[:upper:]' '[:lower:]' | head -c 10)
+fi
+
+echo "Building with rev $REV"
+
 nix build \
     --impure \
     --max-jobs $MAX_JOBS \
     -j $CORES \
-    --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle { path = /kernelcode; rev = $REV; }' \
+    --expr "with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle { path = /kernelcode; rev = \"$REV\"; }" \
     -L
 
 echo "Build completed. Copying results to /kernelcode/build-output/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM nixos/nix:2.18.8
 # default build args
 ARG MAX_JOBS=4
 ARG CORES=4
+ARG REV="unknown"
 
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && echo "max-jobs = $MAX_JOBS" >> /etc/nix/nix.conf \
@@ -15,10 +16,29 @@ COPY . /etc/kernel-builder/
 
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CORES=${CORES}
-ENTRYPOINT ["/bin/sh", "-c", "\
-    GIT_REV=$(cd /kernelcode && git rev-parse HEAD 2>/dev/null || echo \"unknown\") && \
-    nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle { path = /kernelcode; rev = \"'\"$GIT_REV\"'\"; }' -L && \    mkdir -p /kernelcode/build-output && \
-    cp -r --dereference ./result/* /kernelcode/build-output/ && \
-    chmod -R u+w /kernelcode/build-output && \
-    echo 'Build completed. Results copied to /kernelcode/build-output/'\
-"]
+ENV REV=${REV}
+
+RUN mkdir -p /etc/kernelcode && \
+    cat <<'EOF' > /etc/kernelcode/entry.sh
+#!/bin/sh
+echo "Building Torch Extension Bundle"
+
+nix build \
+    --impure \
+    --max-jobs $MAX_JOBS \
+    -j $CORES \
+    --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle { path = /kernelcode; rev = $REV; }' \
+    -L
+
+echo "Build completed. Copying results to /kernelcode/build-output/"
+
+mkdir -p /kernelcode/build-output
+cp -r --dereference ./result/* /kernelcode/build-output/
+chmod -R u+w /kernelcode/build-output
+
+echo 'Done'
+EOF
+
+RUN chmod +x /etc/kernelcode/entry.sh
+
+ENTRYPOINT ["/etc/kernelcode/entry.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ COPY . /etc/kernel-builder/
 ENV MAX_JOBS=${MAX_JOBS}
 ENV CORES=${CORES}
 ENTRYPOINT ["/bin/sh", "-c", "\
-    nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle /kernelcode' -L && \
-    mkdir -p /kernelcode/build-output && \
+    GIT_REV=$(cd /kernelcode && git rev-parse HEAD 2>/dev/null || echo \"unknown\") && \
+    nix build --impure --max-jobs $MAX_JOBS -j $CORES --expr 'with import /etc/kernel-builder; lib.x86_64-linux.buildTorchExtensionBundle { path = /kernelcode; rev = \"'\"$GIT_REV\"'\"; }' -L && \    mkdir -p /kernelcode/build-output && \
     cp -r --dereference ./result/* /kernelcode/build-output/ && \
     chmod -R u+w /kernelcode/build-output && \
     echo 'Build completed. Results copied to /kernelcode/build-output/'\


### PR DESCRIPTION
This PR updates the Dockerfile to pass a `rev` value to the `buildTorchExtensionBundle` function. This is needed as of https://github.com/huggingface/kernel-builder/pull/84 which includes the rev in all build steps

Note: we attempt to get the sha via `git rev-parse HEAD` from the passed `/kernelcode` and fallback to `"unknown"` in the case it does not exist