### PR TITLE
feat: enable persist output of build2cmake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,21 @@
                   inherit path;
                   rev = revUnderscored;
                 };
+              dumpCmake = 
+                let 
+                  build2cmake = self.packages.${system}.build2cmake;
+                in
+                nixpkgs.legacyPackages.${system}.writeShellScriptBin "dumpCmake" ''
+                  echo "Generating cmake for torch extension..."
+
+                  # Create a directory to store the cmake file
+                  mkdir -p ./cmake-result
+
+                  # Run the command and capture the output
+                  ${build2cmake}/bin/build2cmake generate-torch --ops-id "${revUnderscored}" ${path}/build.toml ./cmake-result --force
+
+                  echo "CMake files generated at ./cmake-result"
+                '';
               };
             }
           );

--- a/flake.nix
+++ b/flake.nix
@@ -75,21 +75,21 @@
                   inherit path;
                   rev = revUnderscored;
                 };
-              dumpCmake = 
-                let 
-                  build2cmake = self.packages.${system}.build2cmake;
-                in
-                nixpkgs.legacyPackages.${system}.writeShellScriptBin "dumpCmake" ''
-                  echo "Generating cmake for torch extension..."
+                dumpCmake =
+                  let
+                    build2cmake = self.packages.${system}.build2cmake;
+                  in
+                  nixpkgs.legacyPackages.${system}.writeShellScriptBin "dumpCmake" ''
+                    echo "Generating cmake for torch extension..."
 
-                  # Create a directory to store the cmake file
-                  mkdir -p ./cmake-result
+                    # Create a directory to store the cmake file
+                    mkdir -p ./cmake-result
 
-                  # Run the command and capture the output
-                  ${build2cmake}/bin/build2cmake generate-torch --ops-id "${revUnderscored}" ${path}/build.toml ./cmake-result --force
+                    # Run the command and capture the output
+                    ${build2cmake}/bin/build2cmake generate-torch --ops-id "${revUnderscored}" ${path}/build.toml ./cmake-result --force
 
-                  echo "CMake files generated at ./cmake-result"
-                '';
+                    echo "CMake files generated at ./cmake-result"
+                  '';
               };
             }
           );


### PR DESCRIPTION
This PR adds a new command to dump the `build2cmake` output into `./cmake-result`. This is helpful when developing and ensuring that the extension build is configured as expected.


```bash
rm flake.lock && nix run .\#buildTree
# Generating cmake for torch extension...
# CMake files generated at ./cmake-result
```

```bash
tree result
# result
# ├── cmake
# │   ├── hipify.py
# │   └── utils.cmake
# ├── CMakeLists.txt
# ├── pyproject.toml
# ├── setup.py
# ├── src
# │   ├── build.toml
# │   ├── residual_rms
# │   │   ├── macros.h
# │   │   ├── residual_rms_dispatch.cu
# │   │   ├── residual_rms_scalar.cu
# │   │   └── residual_rms_vectorized.cu
# │   └── torch-ext
# │       ├── residual_rms
# │       │   └── __init__.py
# │       ├── torch_binding.cpp
# │       └── torch_binding.h
# └── torch-ext
#     ├── registration.h
#     └── residual_rms
#         └── _ops.py

# 7 directories, 15 files

```

