### PR TITLE
Use ROCm 6.2.4 for Torch 2.6 and make compatible with glibc >= 2.27

### DIFF
--- a/build2cmake/src/templates/preamble.cmake
+++ b/build2cmake/src/templates/preamble.cmake
@@ -62,6 +62,10 @@ if(GPU_LANG STREQUAL "CUDA")
   endif()
 elseif(GPU_LANG STREQUAL "HIP")
   set(ROCM_ARCHS "${HIP_SUPPORTED_ARCHS}")
+  # TODO: remove this once we can set specific archs per source file set.
+  override_gpu_arches(GPU_ARCHES
+    ${GPU_LANG}
+    "${${GPU_LANG}_SUPPORTED_ARCHS}")
 else()
   override_gpu_arches(GPU_ARCHES
     ${GPU_LANG}

--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742285724,
-        "narHash": "sha256-2QQn9fzmF/SKW082kXpSrEBgfmwKO2RNT5R91Fn/K4M=",
+        "lastModified": 1743085847,
+        "narHash": "sha256-uWG29p+nhZmGRV1LffWwRGjwtPIXeu1F0YTQbXgB+GU=",
         "owner": "huggingface",
         "repo": "rocm-nix",
-        "rev": "a90de1c2e5698b2f4fe984b5f0faf052f466be49",
+        "rev": "245cdc9bfb4bfafa818711c5f5e0b889afe1ba39",
         "type": "github"
       },
       "original": {

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -9,7 +9,7 @@ let
   abi = torch: if torch.passthru.cxx11Abi then "cxx11" else "cxx98";
   targetPlatform = pkgs.stdenv.targetPlatform.system;
   cudaVersion = torch: "cu${flattenVersion torch.cudaPackages.cudaMajorMinorVersion}";
-  rocmVersion = torch: "rocm-${flattenVersion torch.rocmPackages.hipcc.version}";
+  rocmVersion = torch: "rocm${flattenVersion torch.rocmPackages.hipcc.version}";
   gpuVersion = torch: (if torch.cudaSupport then cudaVersion else rocmVersion) torch;
   torchVersion = torch: flattenVersion torch.version;
 in

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -9,7 +9,8 @@ let
   abi = torch: if torch.passthru.cxx11Abi then "cxx11" else "cxx98";
   targetPlatform = pkgs.stdenv.targetPlatform.system;
   cudaVersion = torch: "cu${flattenVersion torch.cudaPackages.cudaMajorMinorVersion}";
-  rocmVersion = torch: "rocm${flattenVersion torch.rocmPackages.hipcc.version}";
+  rocmVersion =
+    torch: "rocm${flattenVersion (lib.versions.majorMinor torch.rocmPackages.rocm.version)}";
   gpuVersion = torch: (if torch.cudaSupport then cudaVersion else rocmVersion) torch;
   torchVersion = torch: flattenVersion torch.version;
 in

--- a/lib/buildsets.nix
+++ b/lib/buildsets.nix
@@ -10,7 +10,7 @@ let
   overlay = import ../overlay.nix;
 
   # Get versions.
-  inherit (import ../versions.nix { inherit lib; }) buildConfigs cudaVersions;
+  inherit (import ../versions.nix { inherit lib; }) buildConfigs cudaVersions rocmVersions;
 
   flattenVersion = version: lib.replaceStrings [ "." ] [ "_" ] (lib.versions.pad 2 version);
 
@@ -19,17 +19,22 @@ let
     cudaPackages = super."cudaPackages_${flattenVersion cudaVersion}";
   };
 
+  overlayForRocmVersion = rocmVersion: self: super: {
+    rocmPackages = super."rocmPackages_${flattenVersion rocmVersion}";
+  };
+
   # Construct the nixpkgs package set for the given versions.
   pkgsForVersions =
     pkgsByCudaVer:
     {
       gpu,
       cudaVersion ? "",
+      rocmVersion ? "",
       torchVersion,
       cxx11Abi,
     }:
     let
-      pkgs = if gpu == "cuda" then pkgsByCudaVer.${cudaVersion} else pkgsForRocm;
+      pkgs = if gpu == "cuda" then pkgsByCudaVer.${cudaVersion} else pkgsByRocmVer.${rocmVersion};
       torch = pkgs.python3.pkgs."torch_${flattenVersion torchVersion}".override {
         inherit cxx11Abi;
       };
@@ -72,5 +77,28 @@ let
     );
 
   pkgsByCudaVer = pkgsForCudaVersions cudaVersions;
+
+  pkgsForRocmVersions =
+    rocmVersions:
+    builtins.listToAttrs (
+      map (rocmVersion: {
+        name = rocmVersion;
+        value = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            rocmSupport = true;
+          };
+          overlays = [
+            overlay
+            rocm
+            (overlayForRocmVersion rocmVersion)
+          ];
+        };
+      }) rocmVersions
+    );
+
+  pkgsByRocmVer = pkgsForRocmVersions rocmVersions;
+
 in
 map (pkgsForVersions pkgsByCudaVer) (buildConfigs system)

--- a/pkgs/python-modules/torch_2_6/default.nix
+++ b/pkgs/python-modules/torch_2_6/default.nix
@@ -195,7 +195,6 @@ let
       clr
       comgr
       hipblas
-      hipblas-common-dev
       hipblaslt
       hipfft
       hipify-clang

--- a/versions.nix
+++ b/versions.nix
@@ -26,6 +26,17 @@ rec {
     };
   };
 
+  torchRocmVersions = {
+    "2.6" = {
+      rocmVersions = [
+        "6.2.4"
+      ];
+      cxx11Abi = [
+        true
+      ];
+    };
+  };
+
   # Upstream only builds aarch64 for CUDA >= 12.6.
   cudaSupported =
     system: cudaVersion:
@@ -34,6 +45,10 @@ rec {
 
   cudaVersions = lib.flatten (
     builtins.map (versionInfo: versionInfo.cudaVersions) (builtins.attrValues torchCudaVersions)
+  );
+
+  rocmVersions = lib.flatten (
+    builtins.map (versionInfo: versionInfo.rocmVersions) (builtins.attrValues torchRocmVersions)
   );
 
   # All build configurations supported by Torch.
@@ -51,18 +66,17 @@ rec {
           }
         ) torchCudaVersions
       );
-      # ROCm always uses the C++11 ABI.
-      rocm =
-        map
-          (torchVersion: {
-            inherit torchVersion;
-            gpu = "rocm";
-            cxx11Abi = true;
-          })
-          [
-            "2.5"
-            "2.6"
-          ];
+      rocm = lib.flatten (
+        lib.mapAttrsToList (
+          torchVersion: versionInfo:
+          lib.cartesianProduct {
+            rocmVersion = versionInfo.rocmVersions;
+            cxx11Abi = versionInfo.cxx11Abi;
+            gpu = [ "rocm" ];
+            torchVersion = [ torchVersion ];
+          }
+        ) torchRocmVersions
+      );
     in
     cuda ++ (lib.optionals (system == "x86_64-linux") rocm);
 }


### PR DESCRIPTION
A couple of related changes:

- Adjust to the changes in `rocm-nix` and use it to get the proper version of ROCm (6.2.4) for Torch 2.6.
- Build ROCm extensions against glibc 2.27 for backwards compat.
- Set the ROCm archs to build, so that we do not only build for gfx906.
- Remove a spurious dash from ROCm kernel build names.