### PR TITLE
Build the Torch binding first

### DIFF
--- a/build2cmake/src/templates/torch-binding.cmake
+++ b/build2cmake/src/templates/torch-binding.cmake
@@ -1,0 +1,17 @@
+get_torch_gpu_compiler_flags(GPU_FLAGS ${GPU_LANG})
+list(APPEND GPU_FLAGS ${TORCH_GPU_FLAGS})
+
+set(TORCH_{{name}}_SRC
+  {{ src|join(' ') }}
+)
+
+{% if includes %}
+# TODO: check if CLion support this:
+# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
+set_source_files_properties(
+  {{'${TORCH_' + name + '_SRC}'}}
+  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
+{% endif %}
+
+list(APPEND SRC {{'"${TORCH_' + name + '_SRC}"'}})
+

--- a/build2cmake/src/templates/torch-extension.cmake
+++ b/build2cmake/src/templates/torch-extension.cmake
@@ -1,20 +1,3 @@
-get_torch_gpu_compiler_flags(GPU_FLAGS ${GPU_LANG})
-list(APPEND GPU_FLAGS ${TORCH_GPU_FLAGS})
-
-set(TORCH_{{name}}_SRC
-  {{ src|join(' ') }}
-)
-
-{% if includes %}
-# TODO: check if CLion support this:
-# https://youtrack.jetbrains.com/issue/CPP-16510/CLion-does-not-handle-per-file-include-directories
-set_source_files_properties(
-  {{'${TORCH_' + name + '_SRC}'}}
-  PROPERTIES INCLUDE_DIRECTORIES "{{ includes }}")
-{% endif %}
-
-list(APPEND SRC {{'"${TORCH_' + name + '_SRC}"'}})
-
 define_gpu_extension_target(
   {{ ops_name }}
   DESTINATION {{ ops_name }}


### PR DESCRIPTION
This gives us errors earlier in case the bindings are not correct.