### PR TITLE
Add shells for kernel development

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -14,6 +14,38 @@ nix build .#bundle -L
 You can put this `flake.nix` in your own kernel's root directory to
 get add Nix support to your kernel.
 
+## Shell for local development
+
+`kernel-builder` provides shells for developing kernels. In such a shell,
+all required dependencies are available, as well as `build2cmake` for generating
+project files. For example:
+
+```bash
+$ nix develop
+$ build2cmake generate-torch build.toml
+$ cmake -B build-ext
+$ cmake --build build-ext
+```
+
+If you want to test the kernel as a Python package, you can make a virtual
+environment inside the shell:
+
+```bash
+$ nix develop
+$ build2cmake generate-torch build.toml
+$ python -m venv .venv
+$ source .venv/bin/activate
+$ pip install --no-build-isolation -e .
+```
+
+Development shells are available for every build configuration. For
+instance, you can get a Torch 2.6 development shell for ROCm extensions
+using:
+
+```bash
+$ nix develop .#devShells.torch26-cxx11-rocm62-x86_64-linux
+```
+
 ## Shell for testing a kernel
 
 You can also start a development shell. This will give you a Python interpreter
@@ -22,7 +54,7 @@ tests:
 
 ```bash
 cd examples/activation
-nix develop -L
+nix develop -L .#test
 python -m pytest tests
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,13 @@
             in
             {
               devShells = rec {
-                default = shells."torch26-cxx98-cu126-${system}";
-                shells = build.torchExtensionShells {
+                default = devShells."torch26-cxx98-cu126-${system}";
+                test = testShells."torch26-cxx98-cu126-${system}";
+                devShells = build.torchDevShells {
+                  inherit path;
+                  rev = revUnderscored;
+                };
+                testShells = build.torchExtensionShells {
                   inherit path;
                   rev = revUnderscored;
                 };


### PR DESCRIPTION
* `nix develop` will give you a shell with all kernel development dependencies, including `build2cmake` for generating project files.
* `nix develop .#test` will build the kernel and give a shell with the kernel in PYTHONPATH to run tests.

Fixes #8.