### PR TITLE
Hotfix: pass through nvcc threads again

### DIFF
--- a/build2cmake/src/templates/torch-binding.cmake
+++ b/build2cmake/src/templates/torch-binding.cmake
@@ -1,4 +1,4 @@
-get_torch_gpu_compiler_flags(GPU_FLAGS ${GPU_LANG})
+get_torch_gpu_compiler_flags(TORCH_GPU_FLAGS ${GPU_LANG})
 list(APPEND GPU_FLAGS ${TORCH_GPU_FLAGS})
 
 set(TORCH_{{name}}_SRC


### PR DESCRIPTION
The flags set before the torch binding were overridden by Torch flags. This was currently only the number of nvcc threads.