### PR TITLE
build2cmake: fix inclusion of universal pyproject.toml in derivation

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -38,6 +38,11 @@ jobs:
       - name: Copy relu kernel
         run: cp -rL examples/relu/result relu-kernel
 
+      - name: Build silu-and-mul-universal kernel
+        run: ( cd examples/silu-and-mul-universal && nix build .\#redistributable.torch25-cxx98-cu121-x86_64-linux )
+      - name: Copy silu-and-mul-universal kernel
+        run: cp -rL examples/silu-and-mul-universal/result silu-and-mul-universal-kernel
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image

--- a/examples/silu-and-mul-universal/build.toml
+++ b/examples/silu-and-mul-universal/build.toml
@@ -1,0 +1,5 @@
+[general]
+name = "silu_and_mul_universal"
+
+[torch]
+universal = true

--- a/examples/silu-and-mul-universal/flake.nix
+++ b/examples/silu-and-mul-universal/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for kernels tests";
+
+  inputs = {
+    kernel-builder.url = "path:../..";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genFlakeOutputs {
+      path = ./.;
+      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
+    };
+}

--- a/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/__init__.py
+++ b/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/__init__.py
@@ -1,0 +1,7 @@
+import torch
+
+def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    return F.silu(x[..., :d]) * x[..., d:]
+
+__all__ = ["silu_and_mul"]

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -92,7 +92,7 @@ rec {
     if buildConfig.torch.universal or false then
       # No torch extension sources? Treat it as a noarch package.
       pkgs.callPackage ./torch-extension-noarch ({
-        inherit src;
+        inherit src rev;
         extensionName = buildConfig.general.name;
       })
     else

--- a/lib/torch-extension-noarch/default.nix
+++ b/lib/torch-extension-noarch/default.nix
@@ -1,6 +1,9 @@
 {
   stdenv,
   extensionName,
+  rev,
+
+  build2cmake,
 
   src,
 }:
@@ -9,6 +12,15 @@ stdenv.mkDerivation (prevAttrs: {
   name = "${extensionName}-torch-ext";
 
   inherit src;
+
+  nativeBuildInputs = [ build2cmake ];
+
+  # We do not strictly need this, since we don't use the setuptools-based
+  # build. But `build2cmake` does proper validation of the build.toml, so
+  # we run it anyway.
+  postPatch = ''
+    build2cmake generate-torch --ops-id ${rev} build.toml
+  '';
 
   installPhase = ''
     mkdir -p $out

--- a/pkgs/build2cmake/default.nix
+++ b/pkgs/build2cmake/default.nix
@@ -17,6 +17,7 @@ rustPlatform.buildRustPackage {
         file.name == "Cargo.toml"
         || file.name == "Cargo.lock"
         || file.name == "pyproject.toml"
+        || file.name == "pyproject_universal.toml"
         || file.name == "cuda_supported_archs.json"
         || (builtins.any file.hasExt [
           "cmake"

--- a/tests/Dockerfile.test-kernel
+++ b/tests/Dockerfile.test-kernel
@@ -68,9 +68,13 @@ RUN uv add numpy pytest
 # Copy kernels and tests
 COPY activation-kernel ./activation-kernel
 COPY cutlass-gemm-kernel ./cutlass-gemm-kernel
+COPY silu-and-mul-universal-kernel ./silu-and-mul-universal-kernel
 COPY examples/activation/tests ./activation_tests
 COPY examples/cutlass-gemm/tests ./tests/cutlass_gemm_tests
 
 # Run tests
-ENV PYTHONPATH="activation-kernel:cutlass-gemm-kernel:$PYTHONPATH"
+ENV PYTHONPATH="activation-kernel:cutlass-gemm-kernel:silu-and-mul-universal-kernel:$PYTHONPATH"
 CMD ["/bin/sh", "-c", ".venv/bin/pytest", "activation_tests", "cutlass_gemm_tests"] 
+
+# We only care about importing, the kernel is trivial.
+CMD ["/bin/sh", "-c", ".venv/bin/python", "-c", "'import silu_and_mul_universal'"] 


### PR DESCRIPTION
This made `build2cmake` failed in the specific case of doing `nix develop` on a universal kernel.