### PR TITLE
Generate `_ops` module for universal kernels as well

### DIFF
--- a/build2cmake/src/main.rs
+++ b/build2cmake/src/main.rs
@@ -92,7 +92,7 @@ fn generate_torch(
 
     if let Some(torch_ext) = build.torch.as_ref() {
         if torch_ext.universal {
-            write_torch_universal_ext(&env, &build, target_dir, force)?;
+            write_torch_universal_ext(&env, &build, target_dir, force, ops_id)?;
         } else {
             write_torch_ext(&env, &build, target_dir, force, ops_id)?;
         }

--- a/build2cmake/src/templates/_ops-universal.py
+++ b/build2cmake/src/templates/_ops-universal.py
@@ -1,0 +1,8 @@
+import torch
+ops = torch.ops.{{ ops_name }}
+
+def add_op_namespace_prefix(op_name: str):
+    """
+    Prefix op by namespace.
+    """
+    return f"{{ ops_name }}::{op_name}"

--- a/build2cmake/src/torch.rs
+++ b/build2cmake/src/torch.rs
@@ -15,7 +15,7 @@ static REGISTRATION_H: &str = include_str!("templates/registration.h");
 static HIPIFY: &str = include_str!("cmake/hipify.py");
 static CUDA_SUPPORTED_ARCHS_JSON: &str = include_str!("cuda_supported_archs.json");
 
-fn kernel_ops_identifier(name: &str, ops_id: Option<String>) -> String {
+pub fn kernel_ops_identifier(name: &str, ops_id: Option<String>) -> String {
     let identifier = ops_id.unwrap_or_else(|| {
         // Generate a random string when no ops_id is provided
         let mut rng = rand::thread_rng();

--- a/build2cmake/src/torch_universal.rs
+++ b/build2cmake/src/torch_universal.rs
@@ -6,6 +6,7 @@ use minijinja::{context, Environment};
 use crate::{
     config::{Build, Torch},
     fileset::FileSet,
+    torch::kernel_ops_identifier,
 };
 
 pub fn write_torch_universal_ext(
@@ -13,6 +14,7 @@ pub fn write_torch_universal_ext(
     build: &Build,
     target_dir: PathBuf,
     force: bool,
+    ops_id: Option<String>,
 ) -> Result<()> {
     let torch_ext = match build.torch.as_ref() {
         Some(torch_ext) => torch_ext,
@@ -21,9 +23,37 @@ pub fn write_torch_universal_ext(
 
     let mut file_set = FileSet::default();
 
+    let ops_name = kernel_ops_identifier(&build.general.name, ops_id);
+
+    write_ops_py(env, &build.general.name, &ops_name, &mut file_set)?;
     write_pyproject_toml(env, torch_ext, &build.general.name, &mut file_set)?;
 
     file_set.write(&target_dir, force)?;
+
+    Ok(())
+}
+
+fn write_ops_py(
+    env: &Environment,
+    name: &str,
+    ops_name: &str,
+    file_set: &mut FileSet,
+) -> Result<()> {
+    let mut path = PathBuf::new();
+    path.push("torch-ext");
+    path.push(name);
+    path.push("_ops.py");
+    let writer = file_set.entry(path);
+
+    env.get_template("_ops-universal.py")
+        .wrap_err("Cannot get _ops-universal.py template")?
+        .render_to_write(
+            context! {
+                ops_name => ops_name,
+            },
+            writer,
+        )
+        .wrap_err("Cannot render kernel template")?;
 
     Ok(())
 }

--- a/examples/silu-and-mul-universal/tests/test_silu_and_mul.py
+++ b/examples/silu-and-mul-universal/tests/test_silu_and_mul.py
@@ -1,0 +1,46 @@
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.library import opcheck
+
+from silu_and_mul_universal import ops, silu_and_mul
+
+
+def silu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    return F.silu(x[..., :d]) * x[..., d:]
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("requires_grad", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_opcheck(device, requires_grad, dtype):
+    torch.manual_seed(42)
+    x = torch.randn(32, 128, device=device, requires_grad=requires_grad, dtype=dtype)
+    opcheck(ops.silu_and_mul, (x,))
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("requires_grad", [False, True])
+# Only do float32, the numerical instabilities of float16 and bfloat16
+# are too large with the different orderings of computing the gradients.
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_silu_and_mul(device, requires_grad, dtype):
+    torch.manual_seed(42)
+    x_ref = torch.randn(
+        32, 128, device=device, requires_grad=requires_grad, dtype=dtype
+    )
+    x = torch.empty(32, 128, device=device, requires_grad=requires_grad, dtype=dtype)
+    with torch.no_grad():
+        x.copy_(x_ref)
+
+    y_ref = silu_and_mul_ref(x_ref)
+    y = silu_and_mul(x)
+
+    torch.testing.assert_close(y_ref, y)
+
+    if requires_grad:
+        d_y = torch.randn((32, 64), device=device, dtype=dtype)
+        y_ref.backward(d_y)
+        y.backward(d_y)
+        torch.testing.assert_close(x_ref.grad, x.grad)

--- a/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/__init__.py
+++ b/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/__init__.py
@@ -1,7 +1,11 @@
 import torch
 
+from ._ops import ops
+from .silu_and_mul import _silu_and_mul
+
+
 def silu_and_mul(x: torch.Tensor) -> torch.Tensor:
-    d = x.shape[-1] // 2
-    return F.silu(x[..., :d]) * x[..., d:]
+    return ops.silu_and_mul(x)
+
 
 __all__ = ["silu_and_mul"]

--- a/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/silu_and_mul.py
+++ b/examples/silu-and-mul-universal/torch-ext/silu_and_mul_universal/silu_and_mul.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn.functional as F
+
+from ._ops import add_op_namespace_prefix
+
+
+@torch.library.custom_op(add_op_namespace_prefix("silu_and_mul"), mutates_args=())
+def _silu_and_mul(x: torch.Tensor) -> torch.Tensor:
+    d = x.shape[-1] // 2
+    return F.silu(x[..., :d]) * x[..., d:]
+
+
+def backward(ctx, grad_output):
+    x = ctx.saved_tensors[0]
+    d = x.shape[-1] // 2
+    x1, x2 = x[..., :d], x[..., d:]
+    sigmoid_x1 = torch.sigmoid(x1)
+    silu_x1 = F.silu(x1)
+    dsilu_dx1 = sigmoid_x1 + silu_x1 * (1 - sigmoid_x1)
+    dx1 = grad_output * x2 * dsilu_dx1
+    dx2 = grad_output * silu_x1
+    return torch.cat([dx1, dx2], dim=-1)
+
+
+def setup_context(ctx, inputs, output):
+    (x,) = inputs
+    ctx.save_for_backward(x)
+
+
+_silu_and_mul.register_autograd(backward, setup_context=setup_context)
+
+
+@_silu_and_mul.register_fake
+def _(x: torch.Tensor) -> torch.Tensor:
+    return x.new_empty(x.shape[0], x.shape[1] // 2)

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -92,7 +92,7 @@ rec {
     if buildConfig.torch.universal or false then
       # No torch extension sources? Treat it as a noarch package.
       pkgs.callPackage ./torch-extension-noarch ({
-        inherit src rev;
+        inherit src rev torch;
         extensionName = buildConfig.general.name;
       })
     else

--- a/lib/torch-extension-noarch/default.nix
+++ b/lib/torch-extension-noarch/default.nix
@@ -4,6 +4,7 @@
   rev,
 
   build2cmake,
+  torch,
 
   src,
 }:
@@ -13,7 +14,13 @@ stdenv.mkDerivation (prevAttrs: {
 
   inherit src;
 
+  # Add Torch as a dependency, so that devshells for universal kernels
+  # also get torch as a build input.
+  buildInputs = [ torch ];
+
   nativeBuildInputs = [ build2cmake ];
+
+  dontBuild = true;
 
   # We do not strictly need this, since we don't use the setuptools-based
   # build. But `build2cmake` does proper validation of the build.toml, so


### PR DESCRIPTION
This is needed when a universal kernel registers ops, since we want the ops namespace to be unique. Also extend silu_and_mul_universal example to test op registration.