### PR TITLE
Add a CUDA 12.9 build variant for Torch 2.7

### DIFF
--- a/.github/workflows/check_variants.yaml
+++ b/.github/workflows/check_variants.yaml
@@ -17,22 +17,22 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Generate variants JSON
-        run: nix eval --raw .#lib.allBuildVariantsJSON | nix run nixpkgs#jq > build-variants.json
+        run: nix eval --raw .#lib.allBuildVariantsJSON | nix run nixpkgs#jq 'walk(if type == "array" then sort else . end)' > build-variants.json
       - name: Check if variants JSON is up-to-date
         run: |
           if git diff --exit-code build-variants.json; then
             echo "✅ variants.json is up-to-date"
           else
-            echo "🛑 regenerate variants.json: nix eval --raw .#lib.allBuildVariantsJSON | nix run nixpkgs#jq > build-variants.json"
+            echo "🛑 regenerate variants.json: nix eval --raw .#lib.allBuildVariantsJSON | nix run nixpkgs#jq 'walk(if type == "array" then sort else . end)' > build-variants.json"
             exit 1
           fi
       - name: Generate variants Markdown
-        run: scripts/gen_variants_markdown.py
+        run: nix run nixpkgs#python3 scripts/gen_variants_markdown.py
       - name: Check if variants Markdown is up-to-date
         run: |
           if git diff --exit-code docs/build-variants.md; then
             echo "✅ docs/build-variants.md is up-to-date"
           else
-            echo "🛑 regenerate docs/build-variants: scripts/gen_variants_markdown.py"
+            echo "🛑 regenerate docs/build-variants: nix run nixpkgs#python3 scripts/gen_variants_markdown.py"
             exit 1
           fi

--- a/build-variants.json
+++ b/build-variants.json
@@ -10,10 +10,10 @@
   "x86_64-linux": {
     "cuda": [
       "torch26-cxx11-cu118-x86_64-linux",
-      "torch26-cxx98-cu118-x86_64-linux",
       "torch26-cxx11-cu124-x86_64-linux",
-      "torch26-cxx98-cu124-x86_64-linux",
       "torch26-cxx11-cu126-x86_64-linux",
+      "torch26-cxx98-cu118-x86_64-linux",
+      "torch26-cxx98-cu124-x86_64-linux",
       "torch26-cxx98-cu126-x86_64-linux",
       "torch27-cxx11-cu118-x86_64-linux",
       "torch27-cxx11-cu126-x86_64-linux",

--- a/docs/build-variants.md
+++ b/docs/build-variants.md
@@ -15,10 +15,10 @@ available. This list will be updated as new PyTorch versions are released.
 ## CUDA x86_64-linux
 
 - `torch26-cxx11-cu118-x86_64-linux`
-- `torch26-cxx98-cu118-x86_64-linux`
 - `torch26-cxx11-cu124-x86_64-linux`
-- `torch26-cxx98-cu124-x86_64-linux`
 - `torch26-cxx11-cu126-x86_64-linux`
+- `torch26-cxx98-cu118-x86_64-linux`
+- `torch26-cxx98-cu124-x86_64-linux`
 - `torch26-cxx98-cu126-x86_64-linux`
 - `torch27-cxx11-cu118-x86_64-linux`
 - `torch27-cxx11-cu126-x86_64-linux`

--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743559129,
-        "narHash": "sha256-7gpAWsENV3tY2HmeHYQ2MoQxGpys+jQWnkS/BHAMXVk=",
-        "owner": "nixos",
+        "lastModified": 1746711195,
+        "narHash": "sha256-bSpM2ySq12PBOVN7jZdzXsc99iRoYOyolh5wz43+CjQ=",
+        "owner": "danieldk",
         "repo": "nixpkgs",
-        "rev": "adae22bea8bcc0aa2fd6e8732044660fb7755f5e",
+        "rev": "6b7a66b06ccb09ac95872ac6ddf952e0660672ab",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
+        "owner": "danieldk",
+        "ref": "kernel-builder-cuda-12.9.0",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,8 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+    #nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable-small";
+    nixpkgs.url = "github:danieldk/nixpkgs/kernel-builder-cuda-12.9.0";
     flake-compat.url = "github:edolstra/flake-compat";
     rocm-nix = {
       url = "github:huggingface/rocm-nix";
@@ -85,6 +86,7 @@
                 };
                 redistributable = build.buildDistTorchExtensions {
                   inherit path;
+                  buildSets = buildSetPerSystem.${system};
                   rev = revUnderscored;
                 };
                 buildTree =

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -2,6 +2,7 @@
   gpu,
   pkgs,
   torch,
+  upstreamVariant,
 }:
 let
   inherit (pkgs) lib;

--- a/lib/buildsets.nix
+++ b/lib/buildsets.nix
@@ -32,6 +32,7 @@ let
       rocmVersion ? "",
       torchVersion,
       cxx11Abi,
+      upstreamVariant ? false,
     }:
     let
       pkgs = if gpu == "cuda" then pkgsByCudaVer.${cudaVersion} else pkgsByRocmVer.${rocmVersion};
@@ -40,7 +41,12 @@ let
       };
     in
     {
-      inherit gpu pkgs torch;
+      inherit
+        gpu
+        pkgs
+        torch
+        upstreamVariant
+        ;
     };
 
   pkgsForRocm = import nixpkgs {

--- a/pkgs/python-modules/torch_2_7/default.nix
+++ b/pkgs/python-modules/torch_2_7/default.nix
@@ -126,7 +126,7 @@ let
   supportedTorchCudaCapabilities =
     let
       # https://github.com/pytorch/pytorch/blob/release/2.7/.ci/manywheel/build_cuda.sh
-      capsPerCudaVersion = {
+      capsPerCudaVersion = rec {
         "12.8" = [
           "7.5"
           "8.0"
@@ -162,6 +162,16 @@ let
           "8.0"
           "8.6"
           "9.0"
+        ];
+
+        # Not in upstream yet, so use same capabilities as 12.8.
+        "12.9" = [
+          "7.5"
+          "8.0"
+          "8.6"
+          "9.0"
+          "10.0"
+          "12.0"
         ];
       };
       real = capsPerCudaVersion."${lib.versions.majorMinor cudaPackages.cudaVersion}";


### PR DESCRIPTION
This change adds a CUDA 12.9 build variant. Since this is not a variant supported/distributed by upstream, we add an `upstreamVariant` attribute to the Torch variants. A variant is only a candidate for a kernel's `bundle` package when `upstreamVariant = true`.

Todo: also use `upstreamVariant` in generating variant JSON.