### PR TITLE
Provide better errors when deserializing `build.toml`

### DIFF
--- a/build2cmake/Cargo.lock
+++ b/build2cmake/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
 name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +82,7 @@ dependencies = [
  "minijinja-embed",
  "rand",
  "serde",
+ "serde-value",
  "serde_json",
  "toml",
 ]
@@ -462,6 +469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46d70b7597f2d4149308210d5dc7ab79f1248238a27c1ab1a3eefd95d20c4cca"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +499,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -576,6 +601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/build2cmake/Cargo.toml
+++ b/build2cmake/Cargo.toml
@@ -19,6 +19,7 @@ minijinja-embed = "2.5"
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde-value = "0.7"
 toml = "0.8"
 
 [build-dependencies]

--- a/build2cmake/src/config/mod.rs
+++ b/build2cmake/src/config/mod.rs
@@ -4,13 +4,31 @@ use serde::Deserialize;
 pub mod v1;
 
 mod v2;
+use serde_value::Value;
 pub use v2::{Backend, Build, Dependencies, Kernel, Torch};
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug)]
 pub enum BuildCompat {
     V1(v1::Build),
     V2(Build),
+}
+
+impl<'de> Deserialize<'de> for BuildCompat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        match v1::Build::deserialize(value.clone()) {
+            Ok(v1_build) => Ok(BuildCompat::V1(v1_build)),
+            Err(_) => {
+                let v2_build: Build =
+                    Build::deserialize(value).map_err(serde::de::Error::custom)?;
+                Ok(BuildCompat::V2(v2_build))
+            }
+        }
+    }
 }
 
 impl TryFrom<BuildCompat> for Build {


### PR DESCRIPTION
Before this change when there was an error in `build.toml`, one would get a generic error:

```
Error: Cannot parse TOML in /Users/daniel/git/relu-metal/build.toml

Caused by:
    data did not match any variant of untagged enum BuildCompat
```

However, what we want is to give the error when trying to parse as the V2 format, since the V1 format is only there for backwards compat/updates. With this change the error of parsing as V2 is bubbled up. For instance:

```
Error: Cannot parse TOML in /Users/daniel/git/relu-metal/build.toml

Caused by:
    Unknown variant metal. Expected one of cuda, rocm
```