### PR TITLE
feat: allow addtion of python libs for testing in build config

### DIFF
--- a/build2cmake/flake.nix
+++ b/build2cmake/flake.nix
@@ -7,10 +7,10 @@
   };
 
   outputs =
-    {
-      self,
-      flake-utils,
-      nixpkgs,
+    { self
+    , flake-utils
+    , nixpkgs
+    ,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:

--- a/build2cmake/src/config/mod.rs
+++ b/build2cmake/src/config/mod.rs
@@ -5,7 +5,7 @@ pub mod v1;
 
 mod v2;
 use serde_value::Value;
-pub use v2::{Backend, Build, Dependencies, Kernel, Torch};
+pub use v2::{Backend, Build, Dependencies, GitPackageSpec, Kernel, Test, Torch};
 
 #[derive(Debug)]
 pub enum BuildCompat {

--- a/build2cmake/src/config/mod.rs
+++ b/build2cmake/src/config/mod.rs
@@ -5,7 +5,7 @@ pub mod v1;
 
 mod v2;
 use serde_value::Value;
-pub use v2::{Backend, Build, Dependencies, GitPackageSpec, Kernel, Test, Torch};
+pub use v2::{Backend, Build, Dependencies, Kernel, Torch};
 
 #[derive(Debug)]
 pub enum BuildCompat {

--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -19,6 +19,8 @@ pub struct Build {
 
     #[serde(rename = "kernel", default)]
     pub kernels: HashMap<String, Kernel>,
+
+    pub test: Option<Test>,
 }
 
 impl Build {
@@ -49,6 +51,30 @@ pub struct Torch {
 
     #[serde(default)]
     pub src: Vec<PathBuf>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct Test {
+    #[serde(default)]
+    pub python_packages: Vec<String>,
+    
+    #[serde(default)]
+    pub python_git_packages: Vec<GitPackageSpec>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+#[serde(untagged)]
+pub enum GitPackageSpec {
+    Url(String),
+    Detailed {
+        url: String,
+        #[serde(rename = "ref")]
+        git_ref: Option<String>,
+        rev: Option<String>,
+        sha256: Option<String>,
+        name: Option<String>,
+    },
 }
 
 impl Torch {
@@ -142,6 +168,7 @@ impl TryFrom<v1::Build> for Build {
             general: General::from(build.general, universal),
             torch: build.torch.map(Into::into),
             kernels: convert_kernels(build.kernels)?,
+            test: None,
         })
     }
 }

--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -58,7 +58,7 @@ pub struct Torch {
 pub struct Test {
     #[serde(default)]
     pub python_packages: Vec<String>,
-    
+
     #[serde(default)]
     pub python_git_packages: Vec<GitPackageSpec>,
 }

--- a/flake.nix
+++ b/flake.nix
@@ -54,7 +54,7 @@
           in
           builtins.toJSON (nixpkgs.lib.foldl' (acc: system: acc // buildVariants system) { } systems);
         genFlakeOutputs =
-          { path, rev }:
+          { path, rev, extraPythonPackages ? [] }:
           flake-utils.lib.eachSystem systems (
             system:
             let
@@ -73,7 +73,7 @@
                   rev = revUnderscored;
                 };
                 testShells = build.torchExtensionShells {
-                  inherit path;
+                  inherit path extraPythonPackages;
                   rev = revUnderscored;
                 };
               };
@@ -182,5 +182,11 @@
     )
     // {
       inherit lib;
+      # Export the helper function
+      mkShellsWithExtraPackages = extraPythonPackages: {
+        genFlakeOutputs =
+          { path, rev }:
+          lib.genFlakeOutputs { inherit path rev extraPythonPackages; };
+      };
     };
 }


### PR DESCRIPTION
This PR adds the ability to include python libraries in the dev shell by specifying them in the `build.toml` file

Example usage:
```toml
[general]
name = "megablocks"
universal = false

[torch]
src = [
  "torch-ext/torch_binding.cpp",
  "torch-ext/torch_binding.h"
]

[kernel.megablocks]
backend = "cuda"
src = [
    "csrc/new_cumsum.h",
    "csrc/new_cumsum.cu",
    "csrc/new_histogram.h",
    "csrc/new_histogram.cu",
    "csrc/new_indices.h",
    "csrc/new_indices.cu",
    "csrc/new_replicate.cu",
    "csrc/new_replicate.h",
    "csrc/new_sort.h",
    "csrc/new_sort.cu",
]
depends = [ "torch", "cutlass_3_8" ]

[test]
python-git-packages = [
    { url = "https://github.com/stanford-futuredata/stk.git", rev = "7363137", sha256 = "0m6g5l9nlwaiwybg5j8dhnz159wdpabdnkzapnn3dsifxrsb59vz" }
]
```

This changes adds support for

- `python-git-packages` for the addition of git repos
- `python_packages` for libraries that are on nixpkgs