### PR TITLE
kernel-abi-check: check macOS minimum version

### DIFF
--- a/kernel-abi-check/src/lib.rs
+++ b/kernel-abi-check/src/lib.rs
@@ -1,5 +1,8 @@
 //! Functions for checking kernel ABI compatibility.
 
+mod macos;
+pub use macos::{check_macos, MacOSViolation};
+
 mod manylinux;
 pub use manylinux::{check_manylinux, ManylinuxViolation};
 

--- a/kernel-abi-check/src/macos.rs
+++ b/kernel-abi-check/src/macos.rs
@@ -25,11 +25,7 @@ fn build_version<Mach: MachHeader>(macho64: &MachOFile<Mach>) -> Result<Option<V
             let minor = ((version_u32 >> 8) as u8) as usize;
             let patch = (version_u32 as u8) as usize;
 
-            return Ok(Some(Version {
-                major,
-                minor,
-                patch,
-            }));
+            return Ok(Some(Version::from(vec![major, minor, patch])));
         }
     }
 
@@ -37,7 +33,7 @@ fn build_version<Mach: MachHeader>(macho64: &MachOFile<Mach>) -> Result<Option<V
 }
 
 /// Check that kernel binary is compatible with the given macOS version.
-pub fn check_macos(file: &File, macos_version: Version) -> Result<BTreeSet<MacOSViolation>> {
+pub fn check_macos(file: &File, macos_version: &Version) -> Result<BTreeSet<MacOSViolation>> {
     let mut violations = BTreeSet::new();
 
     let minos = if let File::MachO64(macho64) = &file {
@@ -48,7 +44,7 @@ pub fn check_macos(file: &File, macos_version: Version) -> Result<BTreeSet<MacOS
 
     match minos {
         Some(object_version) => {
-            if object_version > macos_version {
+            if &object_version > macos_version {
                 violations.insert(MacOSViolation::IncompatibleMinOS {
                     version: object_version,
                 });

--- a/kernel-abi-check/src/macos.rs
+++ b/kernel-abi-check/src/macos.rs
@@ -1,0 +1,63 @@
+use std::collections::BTreeSet;
+
+use eyre::{Context, Result};
+use object::macho::{BuildVersionCommand, LC_BUILD_VERSION};
+use object::read::macho::{MachHeader, MachOFile};
+use object::File;
+
+use crate::Version;
+
+#[derive(Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum MacOSViolation {
+    MissingMinOS,
+    IncompatibleMinOS { version: Version },
+}
+
+fn build_version<Mach: MachHeader>(macho64: &MachOFile<Mach>) -> Result<Option<Version>> {
+    let mut load_commands = macho64
+        .macho_load_commands()
+        .context("Cannot get Mach-O binary load commands")?;
+    while let Some(load_command) = load_commands.next().context("Cannot get load command")? {
+        if load_command.cmd() == LC_BUILD_VERSION {
+            let command = load_command.data::<BuildVersionCommand<Mach::Endian>>()?;
+            let version_u32 = command.minos.get(macho64.endian());
+            let major = (version_u32 >> 16) as usize;
+            let minor = ((version_u32 >> 8) as u8) as usize;
+            let patch = (version_u32 as u8) as usize;
+
+            return Ok(Some(Version {
+                major,
+                minor,
+                patch,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Check that kernel binary is compatible with the given macOS version.
+pub fn check_macos(file: &File, macos_version: Version) -> Result<BTreeSet<MacOSViolation>> {
+    let mut violations = BTreeSet::new();
+
+    let minos = if let File::MachO64(macho64) = &file {
+        build_version(macho64)?
+    } else {
+        return Ok(violations);
+    };
+
+    match minos {
+        Some(object_version) => {
+            if object_version > macos_version {
+                violations.insert(MacOSViolation::IncompatibleMinOS {
+                    version: object_version,
+                });
+            }
+        }
+        None => {
+            violations.insert(MacOSViolation::MissingMinOS);
+        }
+    }
+
+    Ok(violations)
+}

--- a/kernel-abi-check/src/main.rs
+++ b/kernel-abi-check/src/main.rs
@@ -53,8 +53,8 @@ fn main() -> Result<()> {
     )?;
     print_manylinux_violations(&many_linux_violations, &args.manylinux)?;
 
-    let macos_violations = check_macos(&file, args.macos)?;
-    print_macos_violations(&macos_violations, args.macos);
+    let macos_violations = check_macos(&file, &args.macos)?;
+    print_macos_violations(&macos_violations, &args.macos);
 
     let python_abi_violations = check_python_abi(&args.python_abi, file.format(), file.symbols())?;
     print_python_abi_violations(&python_abi_violations, &args.python_abi);
@@ -91,7 +91,7 @@ fn print_manylinux_violations(
     Ok(())
 }
 
-fn print_macos_violations(violations: &BTreeSet<MacOSViolation>, macos_version: Version) {
+fn print_macos_violations(violations: &BTreeSet<MacOSViolation>, macos_version: &Version) {
     if !violations.is_empty() {
         for violation in violations {
             match violation {

--- a/kernel-abi-check/src/main.rs
+++ b/kernel-abi-check/src/main.rs
@@ -6,7 +6,8 @@ use eyre::{Context, Result};
 use object::Object;
 
 use kernel_abi_check::{
-    check_manylinux, check_python_abi, ManylinuxViolation, PythonAbiViolation, Version,
+    check_macos, check_manylinux, check_python_abi, MacOSViolation, ManylinuxViolation,
+    PythonAbiViolation, Version,
 };
 
 /// CLI tool to check library versions
@@ -19,6 +20,10 @@ struct Cli {
     /// Manylinux version.
     #[arg(short, long, value_name = "VERSION", default_value = "manylinux_2_28")]
     manylinux: String,
+
+    /// macOS version.
+    #[arg(long, value_name = "VERSION", default_value = "15.0")]
+    macos: Version,
 
     /// Python ABI version.
     #[arg(short, long, value_name = "VERSION", default_value = "3.9")]
@@ -33,8 +38,8 @@ fn main() -> Result<()> {
     let args = Cli::parse();
 
     eprintln!(
-        "🐍 Checking for compatibility with {} and Python ABI version {}",
-        args.manylinux, args.python_abi
+        "🐍 Checking for compatibility with {}, macOS {}, and Python ABI version {}",
+        args.manylinux, args.macos, args.python_abi
     );
 
     let binary_data = fs::read(args.object).context("Cannot open object file")?;
@@ -48,11 +53,17 @@ fn main() -> Result<()> {
     )?;
     print_manylinux_violations(&many_linux_violations, &args.manylinux)?;
 
+    let macos_violations = check_macos(&file, args.macos)?;
+    print_macos_violations(&macos_violations, args.macos);
+
     let python_abi_violations = check_python_abi(&args.python_abi, file.format(), file.symbols())?;
     print_python_abi_violations(&python_abi_violations, &args.python_abi);
 
-    if !(many_linux_violations.is_empty() && python_abi_violations.is_empty()) {
-        return Err(eyre::eyre!("Incompatible symbols found"));
+    if !(many_linux_violations.is_empty()
+        && macos_violations.is_empty()
+        && python_abi_violations.is_empty())
+    {
+        return Err(eyre::eyre!("Compatibility issues found"));
     } else {
         eprintln!("✅ No compatibility issues found");
     }
@@ -78,6 +89,24 @@ fn print_manylinux_violations(
         }
     }
     Ok(())
+}
+
+fn print_macos_violations(violations: &BTreeSet<MacOSViolation>, macos_version: Version) {
+    if !violations.is_empty() {
+        for violation in violations {
+            match violation {
+                MacOSViolation::MissingMinOS => {
+                    eprintln!("\n⛔ shared library does not contain minimum macOS version");
+                }
+                MacOSViolation::IncompatibleMinOS { version } => {
+                    eprintln!(
+                        "\n⛔ shared library requires macOS version {}, which is newer than {}",
+                        version, macos_version
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn print_python_abi_violations(violations: &BTreeSet<PythonAbiViolation>, python_abi: &Version) {

--- a/kernel-abi-check/src/manylinux/mod.rs
+++ b/kernel-abi-check/src/manylinux/mod.rs
@@ -9,6 +9,14 @@ use serde::Deserialize;
 
 use crate::Version;
 
+#[derive(Debug, Deserialize, Eq, Hash, PartialEq)]
+#[serde(untagged)]
+enum ManyLinuxSymbolVersion {
+    Version(Version),
+    // Work with symbol versions like `TM_1`.
+    Raw(String),
+}
+
 #[derive(Debug, Deserialize)]
 struct ManyLinux {
     name: String,
@@ -16,7 +24,7 @@ struct ManyLinux {
     aliases: Vec<String>,
     #[allow(dead_code)]
     priority: u32,
-    symbol_versions: HashMap<String, HashMap<String, HashSet<String>>>,
+    symbol_versions: HashMap<String, HashMap<String, HashSet<ManyLinuxSymbolVersion>>>,
     #[allow(dead_code)]
     lib_whitelist: Vec<String>,
     #[allow(dead_code)]
@@ -89,7 +97,7 @@ pub fn check_manylinux<'a>(
             };
 
             if let Some(versions) = symbol_versions.get(dep) {
-                if !versions.contains(&version.to_string()) {
+                if !versions.contains(&ManyLinuxSymbolVersion::Version(version.clone())) {
                     violations.insert(ManylinuxViolation::Symbol {
                         name: symbol_name.to_string(),
                         dep: dep.to_string(),

--- a/kernel-abi-check/src/python_abi/mod.rs
+++ b/kernel-abi-check/src/python_abi/mod.rs
@@ -91,7 +91,7 @@ pub fn check_python_abi<'a>(
                 if &abi_info.added > python_abi {
                     violations.insert(PythonAbiViolation::IncompatibleAbi3Symbol {
                         name: symbol_name.to_string(),
-                        added: abi_info.added.clone(),
+                        added: abi_info.added,
                     });
                 }
             }

--- a/kernel-abi-check/src/python_abi/mod.rs
+++ b/kernel-abi-check/src/python_abi/mod.rs
@@ -91,7 +91,7 @@ pub fn check_python_abi<'a>(
                 if &abi_info.added > python_abi {
                     violations.insert(PythonAbiViolation::IncompatibleAbi3Symbol {
                         name: symbol_name.to_string(),
-                        added: abi_info.added,
+                        added: abi_info.added.clone(),
                     });
                 }
             }

--- a/kernel-abi-check/src/version.rs
+++ b/kernel-abi-check/src/version.rs
@@ -1,15 +1,11 @@
 use std::{fmt::Display, str::FromStr};
 
-use eyre::{ensure, eyre, Context, Result};
+use eyre::{ensure, Context, Result};
 use serde::{de, Deserialize, Deserializer};
 
 /// Symbol version.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Version {
-    pub major: usize,
-    pub minor: usize,
-    pub patch: usize,
-}
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Version(Vec<usize>);
 
 impl<'de> Deserialize<'de> for Version {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -23,7 +19,24 @@ impl<'de> Deserialize<'de> for Version {
 
 impl Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+        write!(
+            f,
+            "{}",
+            itertools::join(self.0.iter().map(|v| v.to_string()), ".")
+        )
+    }
+}
+
+impl From<Vec<usize>> for Version {
+    fn from(value: Vec<usize>) -> Self {
+        // Remove trailing zeros for normalization.
+        let mut normalized = value
+            .into_iter()
+            .rev()
+            .skip_while(|&x| x == 0)
+            .collect::<Vec<_>>();
+        normalized.reverse();
+        Version(normalized)
     }
 }
 
@@ -33,33 +46,60 @@ impl FromStr for Version {
     fn from_str(version: &str) -> Result<Self, Self::Err> {
         let version = version.trim().to_owned();
         ensure!(!version.is_empty(), "Empty version string");
-        let mut parts_iter = version.split('.');
-        let major = parts_iter
-            .next()
-            .ok_or_else(|| eyre!("Version does not contain major component: {}", version))?
-            .parse()
-            .context("Version must consist of numbers")?;
-        let minor = parts_iter
-            .next()
-            .map(|s| s.parse())
-            .unwrap_or(Ok(0))
-            .context(format!("Cannot parse minor version in: {}", version))?;
-        let patch = parts_iter
-            .next()
-            .map(|s| s.parse())
-            .unwrap_or(Ok(0))
-            .context(format!("Cannot parse patch version in: {}", version))?;
+        let mut version_parts = Vec::new();
+        for part in version.split('.') {
+            let version_part: usize = part
+                .parse()
+                .context(format!("Version must consist of numbers: {}", version))?;
+            version_parts.push(version_part);
+        }
 
-        ensure!(
-            parts_iter.next().is_none(),
-            "Version contains more than three components: {}",
-            version
+        Ok(Version::from(version_parts))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use crate::Version;
+
+    #[test]
+    fn test_version_equals() {
+        assert_eq!(Version::from(vec![5, 0, 0]), Version::from(vec![5, 0, 0]));
+        assert_eq!(Version::from(vec![5, 0, 0]), Version::from(vec![5]));
+        assert_eq!(Version::from(vec![5]), Version::from(vec![5, 0, 0]));
+    }
+
+    #[test]
+    fn version_ord() {
+        assert_eq!(
+            Version::from(vec![5, 0, 0]).cmp(&Version::from(vec![5, 0, 0])),
+            Ordering::Equal
         );
-
-        Ok(Version {
-            major,
-            minor,
-            patch,
-        })
+        assert_eq!(
+            Version::from(vec![5, 0, 0]).cmp(&Version::from(vec![5])),
+            Ordering::Equal
+        );
+        assert_eq!(
+            Version::from(vec![5]).cmp(&Version::from(vec![5, 0, 0])),
+            Ordering::Equal
+        );
+        assert_eq!(
+            Version::from(vec![5, 0, 0]).cmp(&Version::from(vec![5, 0, 1])),
+            Ordering::Less
+        );
+        assert_eq!(
+            Version::from(vec![5]).cmp(&Version::from(vec![5, 0, 1])),
+            Ordering::Less
+        );
+        assert_eq!(
+            Version::from(vec![5, 0, 1]).cmp(&Version::from(vec![5, 0, 0])),
+            Ordering::Greater
+        );
+        assert_eq!(
+            Version::from(vec![5, 0, 1]).cmp(&Version::from(vec![5])),
+            Ordering::Greater
+        );
     }
 }


### PR DESCRIPTION
If a kernels macOS minimum version (minos) is larger than our spec (currently 15.0), that's a compliance error.