### PR TITLE
Hotfix: append CUDA flags

### DIFF
--- a/build2cmake/src/templates/cuda/kernel.cmake
+++ b/build2cmake/src/templates/cuda/kernel.cmake
@@ -22,11 +22,11 @@ if(GPU_LANG STREQUAL "CUDA")
   {% if cuda_flags %}
 
   foreach(_KERNEL_SRC {{'${' + kernel_name + '_SRC}'}})
-    if(_KERNEL_SRC MATCHES ".*\.cu$")
-      set_source_files_properties(
-        ${_KERNEL_SRC}
-        PROPERTIES
-        COMPILE_OPTIONS "{{ cuda_flags }}"
+    if(_KERNEL_SRC MATCHES ".*\\.cu$")
+      set_property(
+        SOURCE ${_KERNEL_SRC}
+        APPEND PROPERTY
+        COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:CUDA>:{{ cuda_flags }}>"
       )
     endif()
   endforeach()


### PR DESCRIPTION
We were nuking the compute capability flags :cry:.