### PR TITLE
Add `cuda-maxver` option to the `general` section

### DIFF
--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -47,6 +47,8 @@ pub struct General {
     #[serde(default)]
     pub universal: bool,
 
+    pub cuda_maxver: Option<Version>,
+
     pub cuda_minver: Option<Version>,
 }
 
@@ -211,6 +213,7 @@ impl General {
         Self {
             name: general.name,
             universal,
+            cuda_maxver: None,
             cuda_minver: None,
         }
     }

--- a/build2cmake/src/templates/cuda/preamble.cmake
+++ b/build2cmake/src/templates/cuda/preamble.cmake
@@ -43,6 +43,14 @@ if (NOT HIP_FOUND AND CUDA_FOUND)
         "Minimum required version is {{ cuda_minver }}.")
     endif()
   {% endif %}
+
+  {% if cuda_maxver %}
+    if (CUDA_VERSION VERSION_MORE {{ cuda_maxver }})
+      message(FATAL_ERROR "CUDA version ${CUDA_VERSION} is too new. "
+        "Maximum version is {{ cuda_maxver }}.")
+    endif()
+  {% endif %}
+
 elseif(HIP_FOUND)
   set(GPU_LANG "HIP")
 

--- a/build2cmake/src/torch/cuda.rs
+++ b/build2cmake/src/torch/cuda.rs
@@ -164,7 +164,13 @@ fn write_cmake(
 
     let cmake_writer = file_set.entry("CMakeLists.txt");
 
-    render_preamble(env, name, build.general.cuda_minver.as_ref(), cmake_writer)?;
+    render_preamble(
+        env,
+        name,
+        build.general.cuda_minver.as_ref(),
+        build.general.cuda_maxver.as_ref(),
+        cmake_writer,
+    )?;
 
     render_deps(env, build, cmake_writer)?;
 
@@ -343,6 +349,7 @@ pub fn render_preamble(
     env: &Environment,
     name: &str,
     cuda_minver: Option<&Version>,
+    cuda_maxver: Option<&Version>,
     write: &mut impl Write,
 ) -> Result<()> {
     env.get_template("cuda/preamble.cmake")
@@ -351,6 +358,7 @@ pub fn render_preamble(
             context! {
                 name => name,
                 cuda_minver => cuda_minver.map(|v| v.to_string()),
+                cuda_maxver => cuda_maxver.map(|v| v.to_string()),
                 cuda_supported_archs => cuda_supported_archs(),
 
             },

--- a/docs/writing-kernels.md
+++ b/docs/writing-kernels.md
@@ -96,6 +96,11 @@ depends = [ "torch" ]
   Universal kernels do not use the other sections described below.
   A good example of a universal kernel is a Triton kernel.
   Default: `false`
+- `cuda-maxver`: the maximum CUDA toolkit version (inclusive). This option
+  _must not_ be set under normal circumstances, since it can exclude Torch
+  build variants that are [required for compliant kernels](https://github.com/huggingface/kernels/blob/main/docs/kernel-requirements.md).
+  This option is provided for kernels that cause compiler errors on
+  newer CUDA toolkit versions.
 - `cuda-minver`: the minimum required CUDA toolkit version. This option
   _must not_ be set under normal circumstances, since it can exclude Torch
   build variants that are [required for compliant kernels](https://github.com/huggingface/kernels/blob/main/docs/kernel-requirements.md).

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -62,7 +62,11 @@ rec {
     buildConfig: buildSets:
     let
       backends' = backends buildConfig;
-      requiredCuda = buildConfig.general.cuda-minver or "11.8";
+      minCuda = buildConfig.general.cuda-minver or "11.8";
+      maxCuda = buildConfig.general.cuda-minver or "99.9";
+      versionBetween =
+        minver: maxver: ver:
+        builtins.compareVersions ver minver >= 0 && builtins.compareVersions ver maxver <= 0;
       supportedBuildSet =
         buildSet:
         let
@@ -73,7 +77,7 @@ rec {
             || (buildConfig.general.universal or false);
           cudaVersionSupported =
             buildSet.gpu != "cuda"
-            || (lib.strings.versionAtLeast buildSet.pkgs.cudaPackages.cudaMajorMinorVersion requiredCuda);
+            || versionBetween minCuda maxCuda buildSet.pkgs.cudaPackages.cudaMajorMinorVersion;
         in
         backendSupported && cudaVersionSupported;
     in


### PR DESCRIPTION
This is to support kernels for the rare case where e.g. newer CUDA toolkits cause internal compiler errors.