### PR TITLE
Add support for building for a custom set of Torch versions 

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -38,6 +38,10 @@ jobs:
       - name: Copy relu kernel
         run: cp -rL examples/relu/result relu-kernel
 
+      # Just test that we build with the extra torchVersions argument.
+      - name: Build relu kernel (specific Torch version)
+        run: ( cd examples/relu-specific-torch && nix build . )
+
       - name: Build silu-and-mul-universal kernel
         run: ( cd examples/silu-and-mul-universal && nix build .\#redistributable.torch26-cxx98-cu124-x86_64-linux )
       - name: Copy silu-and-mul-universal kernel

--- a/build-variants.json
+++ b/build-variants.json
@@ -1,7 +1,7 @@
 {
   "aarch64-darwin": {
     "metal": [
-      "torch27-cxx11-metal-aarch64-darwin"
+      "torch27-metal-aarch64-darwin"
     ]
   },
   "aarch64-linux": {

--- a/build2cmake/flake.lock
+++ b/build2cmake/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750991972,
+        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -69,7 +69,7 @@ impl Torch {
                 let globs = exts
                     .iter()
                     .filter(|&ext| ext != "py" && ext != "pyi")
-                    .map(|ext| format!("\"**/*.{}\"", ext))
+                    .map(|ext| format!("\"**/*.{ext}\""))
                     .collect_vec();
                 if globs.is_empty() {
                     None
@@ -178,7 +178,7 @@ impl FromStr for Backend {
             "cuda" => Ok(Backend::Cuda),
             "metal" => Ok(Backend::Metal),
             "rocm" => Ok(Backend::Rocm),
-            _ => Err(format!("Unknown backend: {}", s)),
+            _ => Err(format!("Unknown backend: {s}")),
         }
     }
 }

--- a/build2cmake/src/main.rs
+++ b/build2cmake/src/main.rs
@@ -354,12 +354,12 @@ fn clean(
 
     if !errors.is_empty() {
         for error in errors {
-            eprintln!("Error: {}", error);
+            eprintln!("Error: {error}");
         }
         bail!("Some files could not be deleted");
     }
 
-    println!("Cleaned {} generated artifacts.", deleted_count);
+    println!("Cleaned {deleted_count} generated artifacts.");
     Ok(())
 }
 

--- a/build2cmake/src/version.rs
+++ b/build2cmake/src/version.rs
@@ -59,7 +59,7 @@ impl FromStr for Version {
         for part in version.split('.') {
             let version_part: usize = part
                 .parse()
-                .context(format!("Version must consist of numbers: {}", version))?;
+                .context(format!("Version must consist of numbers: {version}"))?;
             version_parts.push(version_part);
         }
 

--- a/docs/build-variants.md
+++ b/docs/build-variants.md
@@ -7,7 +7,7 @@ available. This list will be updated as new PyTorch versions are released.
 
 ## Metal aarch64-darwin
 
-- `torch27-cxx11-metal-aarch64-darwin`
+- `torch27-metal-aarch64-darwin`
 
 ## CUDA aarch64-linux
 

--- a/examples/relu-specific-torch/build.toml
+++ b/examples/relu-specific-torch/build.toml
@@ -1,0 +1,30 @@
+[general]
+name = "relu"
+universal = false
+
+[torch]
+src = [
+    "torch-ext/torch_binding.cpp",
+    "torch-ext/torch_binding.h",
+]
+
+[kernel.activation]
+backend = "cuda"
+depends = ["torch"]
+src = ["relu_cuda/relu.cu"]
+
+[kernel.activation_rocm]
+backend = "rocm"
+rocm-archs = [
+    "gfx906",
+    "gfx908",
+    "gfx90a",
+    "gfx940",
+    "gfx941",
+    "gfx942",
+    "gfx1030",
+    "gfx1100",
+    "gfx1101",
+]
+depends = ["torch"]
+src = ["relu_cuda/relu.cu"]

--- a/examples/relu-specific-torch/flake.nix
+++ b/examples/relu-specific-torch/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Flake for ReLU kernel";
+
+  inputs = {
+    kernel-builder.url = "path:../..";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genFlakeOutputs {
+      path = ./.;
+      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
+      torchVersions = [
+        {
+          torchVersion = "2.7";
+          cudaVersion = "12.8";
+          cxx11Abi = true;
+          systems = [
+            "x86_64-linux"
+            "aarch64-linux"
+          ];
+          upstreamVariant = true;
+        }
+      ];
+    };
+}

--- a/examples/relu-specific-torch/relu_cuda/relu.cu
+++ b/examples/relu-specific-torch/relu_cuda/relu.cu
@@ -1,0 +1,43 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/all.h>
+
+#include <cmath>
+
+__global__ void relu_kernel(float *__restrict__ out,
+                            float const *__restrict__ input, const int d) {
+  const int64_t token_idx = blockIdx.x;
+  for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
+    auto x = input[token_idx * d + idx];
+    out[token_idx * d + idx] = x > 0.0f ? x : 0.0f;
+  }
+}
+
+void relu(torch::Tensor &out, torch::Tensor const &input) {
+  TORCH_CHECK(input.device().is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Float &&
+                  input.scalar_type() == at::ScalarType::Float,
+              "relu_kernel only supports float32");
+
+  TORCH_CHECK(input.sizes() == out.sizes(),
+              "Tensors must have the same shape. Got input shape: ",
+              input.sizes(), " and output shape: ", out.sizes());
+
+  TORCH_CHECK(input.scalar_type() == out.scalar_type(),
+              "Tensors must have the same data type. Got input dtype: ",
+              input.scalar_type(), " and output dtype: ", out.scalar_type());
+
+  TORCH_CHECK(input.device() == out.device(),
+              "Tensors must be on the same device. Got input device: ",
+              input.device(), " and output device: ", out.device());
+
+  int d = input.size(-1);
+  int64_t num_tokens = input.numel() / d;
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(input));
+  const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  relu_kernel<<<grid, block, 0, stream>>>(out.data_ptr<float>(),
+                                          input.data_ptr<float>(), d);
+}

--- a/examples/relu-specific-torch/tests/test_relu.py
+++ b/examples/relu-specific-torch/tests/test_relu.py
@@ -1,0 +1,15 @@
+import platform
+
+import torch
+import torch.nn.functional as F
+
+import relu
+
+
+def test_relu():
+    if platform.system() == "Darwin":
+        device = torch.device("mps")
+    else:
+        device = torch.device("cuda")
+    x = torch.randn(1024, 1024, dtype=torch.float32, device=device)
+    torch.testing.assert_allclose(F.relu(x), relu.relu(x))

--- a/examples/relu-specific-torch/torch-ext/relu/__init__.py
+++ b/examples/relu-specific-torch/torch-ext/relu/__init__.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+import torch
+
+from ._ops import ops
+
+
+def relu(x: torch.Tensor, out: Optional[torch.Tensor] = None) -> torch.Tensor:
+    if out is None:
+        out = torch.empty_like(x)
+    ops.relu(out, x)
+    return out

--- a/examples/relu-specific-torch/torch-ext/torch_binding.cpp
+++ b/examples/relu-specific-torch/torch-ext/torch_binding.cpp
@@ -1,0 +1,15 @@
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def("relu(Tensor! out, Tensor input) -> ()");
+#if defined(CUDA_KERNEL) || defined(ROCM_KERNEL)
+  ops.impl("relu", torch::kCUDA, &relu);
+#elif defined(METAL_KERNEL)
+  ops.impl("relu", torch::kMPS, relu);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/examples/relu-specific-torch/torch-ext/torch_binding.h
+++ b/examples/relu-specific-torch/torch-ext/torch_binding.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <torch/torch.h>
+
+void relu(torch::Tensor &out, torch::Tensor const &input);

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,14 @@
         x86_64-linux
       ];
 
+      torchVersions = import ./versions.nix;
+
       # Create an attrset { "<system>" = [ <buildset> ...]; ... }.
       buildSetPerSystem = builtins.listToAttrs (
         builtins.map (system: {
           name = system;
-          value = import ./lib/buildsets.nix {
-            inherit nixpkgs system;
+          value = import ./lib/build-sets.nix {
+            inherit nixpkgs system torchVersions;
             hf-nix = hf-nix.overlays.default;
           };
         }) systems
@@ -50,9 +52,13 @@
       lib = {
         allBuildVariantsJSON =
           let
-            buildVariants = (import ./versions.nix { inherit (nixpkgs) lib; }).buildVariants;
+            buildVariants =
+              (import ./lib/build-variants.nix {
+                inherit (nixpkgs) lib;
+                inherit torchVersions;
+              }).buildVariants;
           in
-          builtins.toJSON (nixpkgs.lib.foldl' (acc: system: acc // buildVariants system) { } systems);
+          builtins.toJSON buildVariants;
         genFlakeOutputs =
           {
             path,

--- a/kernel-abi-check/flake.lock
+++ b/kernel-abi-check/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750991972,
+        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/kernel-abi-check/src/main.rs
+++ b/kernel-abi-check/src/main.rs
@@ -76,14 +76,11 @@ fn print_manylinux_violations(
     manylinux_version: &str,
 ) -> Result<()> {
     if !violations.is_empty() {
-        eprintln!(
-            "\n⛔ Symbols incompatible with `{}` found:\n",
-            manylinux_version
-        );
+        eprintln!("\n⛔ Symbols incompatible with `{manylinux_version}` found:\n",);
         for violation in violations {
             match violation {
                 ManylinuxViolation::Symbol { name, dep, version } => {
-                    eprintln!("{}_{}: {}", name, dep, version);
+                    eprintln!("{name}_{dep}: {version}");
                 }
             }
         }
@@ -100,8 +97,7 @@ fn print_macos_violations(violations: &BTreeSet<MacOSViolation>, macos_version: 
                 }
                 MacOSViolation::IncompatibleMinOS { version } => {
                     eprintln!(
-                        "\n⛔ shared library requires macOS version {}, which is newer than {}",
-                        version, macos_version
+                        "\n⛔ shared library requires macOS version {version}, which is newer than {macos_version}",
                     );
                 }
             }
@@ -121,10 +117,10 @@ fn print_python_abi_violations(violations: &BTreeSet<PythonAbiViolation>, python
             .collect::<BTreeSet<_>>();
 
         if !newer_abi3_symbols.is_empty() {
-            eprintln!("\n⛔ Symbols >= Python ABI {} found:\n", python_abi);
+            eprintln!("\n⛔ Symbols >= Python ABI {python_abi} found:\n",);
             for violation in newer_abi3_symbols {
                 if let PythonAbiViolation::IncompatibleAbi3Symbol { name, added } = violation {
-                    eprintln!("{}: {}", name, added);
+                    eprintln!("{name}: {added}");
                 }
             }
         }
@@ -133,7 +129,7 @@ fn print_python_abi_violations(violations: &BTreeSet<PythonAbiViolation>, python
             eprintln!("\n⛔ Non-ABI3 symbols found:\n");
             for violation in &non_abi3_symbols {
                 if let PythonAbiViolation::NonAbi3Symbol { name } = violation {
-                    eprintln!("{}", name);
+                    eprintln!("{name}");
                 }
             }
         }

--- a/kernel-abi-check/src/manylinux/mod.rs
+++ b/kernel-abi-check/src/manylinux/mod.rs
@@ -61,12 +61,11 @@ pub fn check_manylinux<'a>(
     let arch_str = architecture.arch_str(endianness)?;
     let symbol_versions = MANYLINUX_VERSIONS
         .get(manylinux_version)
-        .context(format!("Unknown manylinux version: {}", manylinux_version))?
+        .context(format!("Unknown manylinux version: {manylinux_version}"))?
         .symbol_versions
         .get(&arch_str)
         .context(format!(
-            "Cannot find arch `{}` for: {}`",
-            arch_str, manylinux_version
+            "Cannot find arch `{arch_str}` for: {manylinux_version}`"
         ))?;
 
     let mut violations = BTreeSet::new();

--- a/kernel-abi-check/src/version.rs
+++ b/kernel-abi-check/src/version.rs
@@ -50,7 +50,7 @@ impl FromStr for Version {
         for part in version.split('.') {
             let version_part: usize = part
                 .parse()
-                .context(format!("Version must consist of numbers: {}", version))?;
+                .context(format!("Version must consist of numbers: {version}"))?;
             version_parts.push(version_part);
         }
 

--- a/lib/build-variants.nix
+++ b/lib/build-variants.nix
@@ -1,0 +1,55 @@
+{ lib, torchVersions }:
+let
+  inherit (import ./torch-version-utils.nix { inherit lib; })
+    flattenSystems
+    isCuda
+    isMetal
+    isRocm
+    ;
+in
+rec {
+  computeFramework =
+    buildConfig:
+    if buildConfig ? cudaVersion then
+      "cuda"
+    else if buildConfig ? metal then
+      "metal"
+    else if buildConfig ? "rocmVersion" then
+      "rocm"
+    else
+      throw "Could not find compute framework: no CUDA or ROCm version specified and Metal is not enabled";
+
+  # Upstream build variants.
+  buildVariants =
+    let
+      inherit (import ./version-utils.nix { inherit lib; }) abiString flattenVersion;
+      computeString =
+        version:
+        if isCuda version then
+          "cu${flattenVersion (lib.versions.majorMinor version.cudaVersion)}"
+        else if isRocm version then
+          "rocm${flattenVersion (lib.versions.majorMinor version.rocmVersion)}"
+        else if isMetal version then
+          "metal"
+        else
+          throw "No compute framework set in Torch version";
+      buildName =
+        version:
+        if version.system == "aarch64-darwin" then
+          "torch${flattenVersion version.torchVersion}-${computeString version}-${version.system}"
+        else
+          "torch${flattenVersion version.torchVersion}-${abiString version.cxx11Abi}-${computeString version}-${version.system}";
+      upstreamVersions = lib.filter (version: version.upstreamVariant or false);
+    in
+    lib.foldl' (
+      acc: version:
+      let
+        path = [
+          version.system
+          (computeFramework version)
+        ];
+        pathVersions = lib.attrByPath path [ ] acc ++ [ (buildName version) ];
+      in
+      lib.recursiveUpdate acc (lib.setAttrByPath path pathVersions)
+    ) { } (flattenSystems (upstreamVersions torchVersions));
+}

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -1,5 +1,5 @@
 {
-  gpu,
+  buildConfig,
   pkgs,
   torch,
   upstreamVariant,

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -16,6 +16,7 @@ let
   supportedCudaCapabilities = builtins.fromJSON (
     builtins.readFile ../build2cmake/src/cuda_supported_archs.json
   );
+  inherit (import ./torch-version-utils.nix { inherit lib; }) isCuda isMetal isRocm;
 in
 rec {
   resolveDeps = import ./deps.nix { inherit lib; };
@@ -71,12 +72,12 @@ rec {
         buildSet:
         let
           backendSupported =
-            (buildSet.gpu == "cuda" && backends'.cuda)
-            || (buildSet.gpu == "rocm" && backends'.rocm)
-            || (buildSet.gpu == "metal" && backends'.metal)
+            (isCuda buildSet.buildConfig && backends'.cuda)
+            || (isRocm buildSet.buildConfig && backends'.rocm)
+            || (isMetal buildSet.buildConfig && backends'.metal)
             || (buildConfig.general.universal or false);
           cudaVersionSupported =
-            buildSet.gpu != "cuda"
+            isCuda buildSet.buildConfig
             || versionBetween minCuda maxCuda buildSet.pkgs.cudaPackages.cudaMajorMinorVersion;
         in
         backendSupported && cudaVersionSupported;
@@ -86,7 +87,7 @@ rec {
   # Build a single Torch extension.
   buildTorchExtension =
     {
-      gpu,
+      buildConfig,
       pkgs,
       torch,
       upstreamVariant,

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -77,7 +77,7 @@ rec {
             || (isMetal buildSet.buildConfig && backends'.metal)
             || (buildConfig.general.universal or false);
           cudaVersionSupported =
-            isCuda buildSet.buildConfig
+            !(isCuda buildSet.buildConfig)
             || versionBetween minCuda maxCuda buildSet.pkgs.cudaPackages.cudaMajorMinorVersion;
         in
         backendSupported && cudaVersionSupported;

--- a/lib/torch-version-utils.nix
+++ b/lib/torch-version-utils.nix
@@ -1,0 +1,13 @@
+{ lib }:
+{
+  # Expand { systems = [ a b ]; .. } to [ { system = a; ..} { system = b; .. } ]
+  flattenSystems = lib.foldl' (
+    acc: version:
+    acc
+    ++ map (system: (builtins.removeAttrs version [ "systems" ]) // { inherit system; }) version.systems
+  ) [ ];
+
+  isCuda = version: version ? cudaVersion;
+  isMetal = version: version.metal or false;
+  isRocm = version: version ? rocmVersion;
+}

--- a/versions.nix
+++ b/versions.nix
@@ -1,171 +1,110 @@
-{ lib }:
+[
+  {
+    torchVersion = "2.6";
+    cudaVersion = "11.8";
+    cxx11Abi = false;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    cudaVersion = "11.8";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    cudaVersion = "12.4";
+    cxx11Abi = false;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    cudaVersion = "12.4";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    cudaVersion = "12.6";
+    cxx11Abi = false;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    cudaVersion = "12.6";
+    cxx11Abi = true;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.6";
+    rocmVersion = "6.2.4";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
 
-rec {
-  torchVersions = [
-    {
-      torchVersion = "2.6";
-      cudaVersion = "11.8";
-      cxx11Abi = false;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      cudaVersion = "11.8";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      cudaVersion = "12.4";
-      cxx11Abi = false;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      cudaVersion = "12.4";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      cudaVersion = "12.6";
-      cxx11Abi = false;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      cudaVersion = "12.6";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.6";
-      rocmVersion = "6.2.4";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
+  {
+    torchVersion = "2.7";
+    cudaVersion = "11.8";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.7";
+    cudaVersion = "12.6";
+    cxx11Abi = true;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.7";
+    cudaVersion = "12.8";
+    cxx11Abi = true;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.7";
+    rocmVersion = "6.3.4";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    upstreamVariant = true;
+  }
+  {
+    torchVersion = "2.7";
+    cxx11Abi = true;
+    metal = true;
+    systems = [ "aarch64-darwin" ];
+    upstreamVariant = true;
+  }
 
-    {
-      torchVersion = "2.7";
-      cudaVersion = "11.8";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.7";
-      cudaVersion = "12.6";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.7";
-      cudaVersion = "12.8";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.7";
-      rocmVersion = "6.3.4";
-      cxx11Abi = true;
-      upstreamVariant = true;
-    }
-    {
-      torchVersion = "2.7";
-      cxx11Abi = true;
-      metal = true;
-      upstreamVariant = true;
-    }
-
-    # Non-standard versions; not included in bundle builds.
-    {
-      torchVersion = "2.7";
-      cudaVersion = "12.9";
-      cxx11Abi = true;
-    }
-  ];
-
-  cudaVersions =
-    let
-      withCuda = builtins.filter (torchVersion: torchVersion ? cudaVersion) torchVersions;
-    in
-    builtins.map (torchVersion: torchVersion.cudaVersion) withCuda;
-
-  rocmVersions =
-    let
-      withRocm = builtins.filter (torchVersion: torchVersion ? rocmVersion) torchVersions;
-    in
-    builtins.map (torchVersion: torchVersion.rocmVersion) withRocm;
-
-  # Upstream only builds aarch64 for CUDA >= 12.6.
-  isCudaSupported =
-    system: torchVersion:
-    (system == "x86_64-linux" && torchVersion ? cudaVersion)
-    || (
-      system == "aarch64-linux" && lib.strings.versionAtLeast (torchVersion.cudaVersion or "0.0") "12.6"
-    );
-
-  isMetalSupported =
-    system: torchVersion: system == "aarch64-darwin" && (torchVersion.metal or false);
-
-  # ROCm only builds on x86_64.
-  isRocmSupported = system: torchVersion: system == "x86_64-linux" && torchVersion ? rocmVersion;
-
-  isSupported =
-    system: torchVersion:
-    (isCudaSupported system torchVersion)
-    || (isMetalSupported system torchVersion)
-    || (isRocmSupported system torchVersion);
-
-  computeFramework =
-    buildConfig:
-    if buildConfig ? cudaVersion then
-      "cuda"
-    else if buildConfig ? metal then
-      "metal"
-    else if buildConfig ? "rocmVersion" then
-      "rocm"
-    else
-      throw "Could not find compute framework: no CUDA or ROCm version specified and Metal is not enabled";
-
-  # All build configurations supported by Torch.
-  buildConfigs =
-    system:
-    let
-      supported = builtins.filter (isSupported system) torchVersions;
-    in
-    map (version: version // { gpu = computeFramework version; }) supported;
-
-  # Upstream build variants.
-  buildVariants =
-    system:
-    let
-      inherit (import ./lib/version-utils.nix { inherit lib; }) abiString flattenVersion;
-      computeString =
-        buildConfig:
-        if buildConfig.gpu == "cuda" then
-          "cu${flattenVersion (lib.versions.majorMinor buildConfig.cudaVersion)}"
-        else if buildConfig.gpu == "rocm" then
-          "rocm${flattenVersion (lib.versions.majorMinor buildConfig.rocmVersion)}"
-        else if buildConfig.gpu == "metal" then
-          "metal"
-        else
-          throw "Unknown compute framework: ${buildConfig.gpu}";
-      buildName =
-        buildConfig:
-        "torch${flattenVersion buildConfig.torchVersion}-${abiString buildConfig.cxx11Abi}-${computeString buildConfig}-${system}";
-      filterMap = f: xs: builtins.filter (x: x != null) (builtins.map f xs);
-    in
-    {
-      ${system} = lib.zipAttrs (
-        filterMap (
-          buildConfig:
-          if buildConfig.upstreamVariant or false then
-            {
-              ${buildConfig.gpu} = buildName buildConfig;
-            }
-          else
-            null
-        ) (buildConfigs system)
-      );
-    };
-}
+  # Non-standard versions; not included in bundle builds.
+  {
+    torchVersion = "2.7";
+    cudaVersion = "12.9";
+    cxx11Abi = true;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  }
+]


### PR DESCRIPTION
This change adds a `torchVersions` argument to `genFlakeOutputs`. This allows building for unsupported (non-upstream) versions.