### PR TITLE
Add huggingface and nix-community nix caches to flakes

### DIFF
--- a/build2cmake/flake.nix
+++ b/build2cmake/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "A very basic flake";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";

--- a/examples/activation/flake.nix
+++ b/examples/activation/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Flake for activation kernels";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     kernel-builder.url = "path:../..";
   };

--- a/examples/cutlass-gemm/flake.nix
+++ b/examples/cutlass-gemm/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Flake for CUTLASS gemm test kernel";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     kernel-builder.url = "path:../..";
   };

--- a/examples/relu-specific-torch/flake.nix
+++ b/examples/relu-specific-torch/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Flake for ReLU kernel";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     kernel-builder.url = "path:../..";
   };

--- a/examples/relu/flake.nix
+++ b/examples/relu/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Flake for ReLU kernel";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     kernel-builder.url = "path:../..";
   };

--- a/examples/silu-and-mul-universal/flake.nix
+++ b/examples/silu-and-mul-universal/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Flake for kernels tests";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     kernel-builder.url = "path:../..";
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "Kernel builder";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.follows = "hf-nix/nixpkgs";

--- a/kernel-abi-check/flake.nix
+++ b/kernel-abi-check/flake.nix
@@ -1,6 +1,17 @@
 {
   description = "kernel-abi-check devenv";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nix-community.cachix.org"
+      "https://huggingface.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+      "huggingface.cachix.org-1:ynTPbLS0W8ofXd9fDjk1KvoFky9K2jhxe6r4nXAkc/o="
+    ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";


### PR DESCRIPTION
The cuda-maintainers cache is moved into the nix-community cache (more info: https://github.com/SomeoneSerge/nixpkgs-cuda-ci )

The nix-community and huggingface caches really speed up the build process because only the torch without cuda is cached at the default cache.nixos.org. The torch and some other python packages that uses CUDA is cached at nix-community cache.

Otherwise these examples run for hours just to build flake outputs.