### PR TITLE
Add `cuda-minver` option for CUDA kernels

### DIFF
--- a/build2cmake/src/config/v2.rs
+++ b/build2cmake/src/config/v2.rs
@@ -90,6 +90,7 @@ pub enum Kernel {
     Cuda {
         cuda_capabilities: Option<Vec<String>>,
         cuda_flags: Option<Vec<String>>,
+        cuda_minver: Option<Version>,
         cxx_flags: Option<Vec<String>>,
         depends: Vec<Dependencies>,
         include: Option<Vec<String>>,
@@ -256,6 +257,7 @@ fn convert_kernels(v1_kernels: HashMap<String, v1::Kernel>) -> Result<HashMap<St
             Kernel::Cuda {
                 cuda_capabilities: kernel.cuda_capabilities,
                 cuda_flags: None,
+                cuda_minver: None,
                 cxx_flags: None,
                 depends: kernel.depends,
                 include: kernel.include,

--- a/build2cmake/src/templates/cuda/kernel.cmake
+++ b/build2cmake/src/templates/cuda/kernel.cmake
@@ -1,3 +1,7 @@
+{% if cuda_minver %}
+if (CUDA_VERSION VERSION_GREATER_EQUAL {{ cuda_minver }})
+{% endif %}
+
 set({{kernel_name}}_SRC
   {{ sources }}
 )
@@ -50,3 +54,6 @@ elseif(GPU_LANG STREQUAL "HIP")
 {% endif %}
 endif()
 
+{% if cuda_minver %}
+endif()
+{% endif %}

--- a/build2cmake/src/torch/cuda.rs
+++ b/build2cmake/src/torch/cuda.rs
@@ -298,13 +298,19 @@ pub fn render_kernel(
         .collect_vec()
         .join("\n");
 
-    let (cuda_capabilities, rocm_archs, cuda_flags) = match kernel {
+    let (cuda_capabilities, rocm_archs, cuda_flags, cuda_minver) = match kernel {
         Kernel::Cuda {
             cuda_capabilities,
             cuda_flags,
+            cuda_minver,
             ..
-        } => (cuda_capabilities.as_deref(), None, cuda_flags.as_deref()),
-        Kernel::Rocm { rocm_archs, .. } => (None, rocm_archs.as_deref(), None),
+        } => (
+            cuda_capabilities.as_deref(),
+            None,
+            cuda_flags.as_deref(),
+            cuda_minver.as_ref(),
+        ),
+        Kernel::Rocm { rocm_archs, .. } => (None, rocm_archs.as_deref(), None, None),
         _ => unreachable!("Unsupported kernel type for CUDA rendering"),
     };
 
@@ -314,6 +320,7 @@ pub fn render_kernel(
             context! {
                 cuda_capabilities => cuda_capabilities,
                 cuda_flags => cuda_flags.map(|flags| flags.join(";")),
+                cuda_minver => cuda_minver.map(ToString::to_string),
                 cxx_flags => kernel.cxx_flags().map(|flags| flags.join(";")),
                 rocm_archs => rocm_archs,
                 includes => kernel.include().map(prefix_and_join_includes),


### PR DESCRIPTION
This allows for kernels that support all the upstream CUDA versions, but have some 'subkernels' that require a newer CUDA version (e.g. CUDA 12.9 for Blackwell).