### PR TITLE
feat: include cachix instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,17 @@ is updated for the final release.
 
 ## 🚀 Quick Start
 
-We recommend using [Nix](https://nixos.org/download.html) to build kernels. Quick start a build with:
+We recommend using [Nix](https://nixos.org/download.html) to build kernels. To speed up builds, first enable the Hugging Face binary cache:
+
+```bash
+# Install cachix and configure the cache
+cachix use huggingface
+
+# Or run once without installing cachix
+nix run nixpkgs#cachix -- use huggingface
+```
+
+Then quick start a build with:
 
 ```bash
 cd examples/activation

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -19,8 +19,22 @@ and `flake.lock` to your repository, this will ensure that kernel
 builds are reproducible.
 
 Since the kernel builder depends on many packages (e.g. every supported
-PyTorch version), it is recommended to [enable the huggingface cache](https://app.cachix.org/cache/huggingface)
+PyTorch version), it is recommended to enable the huggingface cache
 to avoid expensive rebuilds.
+
+To use the cache, you can either install cachix and configure it:
+
+```bash
+# Install cachix and configure the cache
+cachix use huggingface
+```
+
+Or run it once without installing cachix permanently:
+
+```bash
+# Use cachix without installing it
+nix run nixpkgs#cachix -- use huggingface
+```
 
 The kernel builder also provides Nix development shells with all Torch
 and CUDA/ROCm dependencies needed to develop kernels (see below). If


### PR DESCRIPTION
This PR simply adds `cachix` instructions to the main readme and nix docs to help users get started with the cache for much faster builds