### PR TITLE
Add check that imports the kernel with `kernels`

### DIFF
--- a/build2cmake/src/templates/utils.cmake
+++ b/build2cmake/src/templates/utils.cmake
@@ -498,7 +498,7 @@ function (define_gpu_extension_target GPU_MOD_NAME)
   # Don't use `TORCH_LIBRARIES` for CUDA since it pulls in a bunch of
   # dependencies that are not necessary and may not be installed.
   if (GPU_LANGUAGE STREQUAL "CUDA")
-    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart CUDA::cuda_driver)
+    target_link_libraries(${GPU_MOD_NAME} PRIVATE CUDA::cudart)
   else()
     target_link_libraries(${GPU_MOD_NAME} PRIVATE ${TORCH_LIBRARIES})
   endif()

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1750234878,
-        "narHash": "sha256-q9DRC9zdpzUf88qqg1qbhP1qgJbE2cMtn8oUmosuyT8=",
+        "lastModified": 1751968576,
+        "narHash": "sha256-cmKrlWpNTG/hq1bCaHXfbdm9T+Y6V+5//EHAVc1TLBE=",
         "owner": "huggingface",
         "repo": "hf-nix",
-        "rev": "c7132f90763d756da3e77da62e01be0a4546dc57",
+        "rev": "3fcd1e1b46da91b6691261640ffd6b7123d0cb9e",
         "type": "github"
       },
       "original": {

--- a/lib/torch-extension-noarch/default.nix
+++ b/lib/torch-extension-noarch/default.nix
@@ -4,6 +4,7 @@
   rev,
 
   build2cmake,
+  get-kernel-check,
   torch,
 
   src,
@@ -18,7 +19,10 @@ stdenv.mkDerivation (prevAttrs: {
   # also get torch as a build input.
   buildInputs = [ torch ];
 
-  nativeBuildInputs = [ build2cmake ];
+  nativeBuildInputs = [
+    build2cmake
+    get-kernel-check
+  ];
 
   dontBuild = true;
 
@@ -33,4 +37,8 @@ stdenv.mkDerivation (prevAttrs: {
     mkdir -p $out
     cp -r torch-ext/${extensionName} $out/
   '';
+
+  doInstallCheck = true;
+
+  getKernelCheck = extensionName;
 })

--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -19,6 +19,7 @@
   cmakeNvccThreadsHook,
   ninja,
   build2cmake,
+  get-kernel-check,
   kernel-abi-check,
   python3,
   rewrite-nix-paths-macho,
@@ -80,6 +81,7 @@ stdenv.mkDerivation (prevAttrs: {
 
   nativeBuildInputs =
     [
+      get-kernel-check
       kernel-abi-check
       cmake
       ninja
@@ -177,6 +179,8 @@ stdenv.mkDerivation (prevAttrs: {
     '';
 
   doInstallCheck = true;
+
+  getKernelCheck = extensionName;
 
   # We need access to the host system on Darwin for the Metal compiler.
   __noChroot = stdenv.hostPlatform.isDarwin;

--- a/overlay.nix
+++ b/overlay.nix
@@ -3,9 +3,11 @@ final: prev: {
 
   # Local packages
 
-  kernel-abi-check = prev.callPackage ./pkgs/kernel-abi-check { };
-
   build2cmake = prev.callPackage ./pkgs/build2cmake { };
+
+  get-kernel-check = prev.callPackage ./pkgs/get-kernel-check { };
+
+  kernel-abi-check = prev.callPackage ./pkgs/kernel-abi-check { };
 
   rewrite-nix-paths-macho = prev.callPackage ./pkgs/rewrite-nix-paths-macho { };
 

--- a/pkgs/get-kernel-check/default.nix
+++ b/pkgs/get-kernel-check/default.nix
@@ -1,0 +1,8 @@
+{ makeSetupHook, python3 }:
+
+makeSetupHook {
+  name = "get-kernel-check-hook";
+  propagatedBuildInputs = [
+    (python3.withPackages (ps: with ps; [ kernels ]))
+  ];
+} ./get-kernel-check-hook.sh

--- a/pkgs/get-kernel-check/get-kernel-check-hook.sh
+++ b/pkgs/get-kernel-check/get-kernel-check-hook.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+echo "Sourcing get-kernel-check-hook.sh"
+
+_getKernelCheckHook() {
+  if [ ! -z "${getKernelCheck}" ]; then
+    echo "Checking loading kernel with get_kernel"
+    echo "Check whether the kernel can be loaded with get-kernel: ${getKernelCheck}"
+
+    TMPDIR=$(mktemp -d -t test.XXXXXX) || exit 1
+    trap "rm -rf '$TMPDIR'" EXIT
+
+    # Emulate the bundle layout that kernels expects. This even works
+    # for universal kernels, since kernels checks the non-universal
+    # path first.
+    BUILD_VARIANT=$(python -c "from kernels.utils import build_variant; print(build_variant())")
+    mkdir -p "${TMPDIR}/build"
+    ln -s "$out" "${TMPDIR}/build/${BUILD_VARIANT}"
+
+    python -c "from pathlib import Path; import kernels; kernels.get_local_kernel(Path('${TMPDIR}'), '${getKernelCheck}')"
+  fi
+}
+
+postInstallCheckHooks+=(_getKernelCheckHook)


### PR DESCRIPTION
This verifies that the kernel can actually be loaded with the `kernels` packages, which can fail when e.g. the kernel does not use relative imports.