### PR TITLE
Make get-kernel-check work on macOS

### DIFF
--- a/pkgs/get-kernel-check/get-kernel-check-hook.sh
+++ b/pkgs/get-kernel-check/get-kernel-check-hook.sh
@@ -7,6 +7,15 @@ _getKernelCheckHook() {
     echo "Checking loading kernel with get_kernel"
     echo "Check whether the kernel can be loaded with get-kernel: ${getKernelCheck}"
 
+    # We strip the full library paths from the extension. Unfortunately,
+    # in a Nix environment, the library dependencies cannot be found
+    # anymore. So we have to add the Torch library directory to the
+    # dynamic linker path to get it to pick it up.
+    if [ $(uname -s) == "Darwin" ]; then
+      TORCH_DIR=$(python -c "from pathlib import Path; import torch; print(Path(torch.__file__).parent)")
+      export DYLD_LIBRARY_PATH="${TORCH_DIR}/lib:${DYLD_LIBRARY_PATH}"
+    fi
+
     TMPDIR=$(mktemp -d -t test.XXXXXX) || exit 1
     trap "rm -rf '$TMPDIR'" EXIT
 


### PR DESCRIPTION
This new check failed on macOS. We strip the Nix store prefixes from the extension's library paths. However, this breaks dynamic loading of the extension's library dependencies. Fix this by adding the Torch lib path to the dynamic loader search path during this check.