### PR TITLE
CI: try to build a macOS kernel

### DIFF
--- a/.github/workflows/build_kernel_macos.yaml
+++ b/.github/workflows/build_kernel_macos.yaml
@@ -1,0 +1,24 @@
+name: "Build and test kernel (macOS)"
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened] # trigger on PRs
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build kernel
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v15
+        with:
+          name: huggingface
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      # For now we only test that there are no regressions in building macOS
+      # kernels. Also run tests once we have a macOS runner.
+      - name: Build relu kernel
+        run: ( cd examples/relu && nix build .\#redistributable.torch27-metal-aarch64-darwin -L )


### PR DESCRIPTION
We cannot run tests, since Metal is not supported by GitHub CI runners, but this at least helps us testing if we have a functional build.