### PR TITLE
Add `doGetKernelCheck` option to `genFlakeOutputs`

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -128,6 +128,17 @@ The available packages can be found on [search.nixos.org](https://search.nixos.o
 Keep in mind that these additional dependencies will only be available to
 the Nix shells, not the final kernel uploaded to the Hub.
 
+## Skipping the `get_kernel` check
+
+`kernel-builder` verifies that a kernel can be
+imported with the [`kernels`](https://github.com/huggingface/kernels)
+package. This check can be disabled by passing `doGetKernelCheck = false`
+to `genFlakeOutputs`. **Warning:** it is strongly recommended to keep
+this check enabled, as it is one of the checks that validates that a kernel
+is compliant. This option is primarily intended for kernels with
+`triton.autotune` decorators, which can fail because there is no GPU available
+in the build sandbox.
+
 ## Building a kernel without `flake.nix`
 
 If a kernels source directory does not have a `flake.nix` file, you can build the

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,13 @@
             path,
             rev,
 
+            # This option is not documented on purpose. You should not use it,
+            # if a kernel cannot be imported, it is non-compliant. This is for
+            # one exceptional case: packaging a third-party kernel (where you
+            # want to stay close to upstream) where importing the kernel will
+            # fail in a GPU-less sandbox. Even in that case, it's better to lazily
+            # load the part with this functionality.
+            doGetKernelCheck ? true,
             pythonCheckInputs ? pkgs: [ ],
             pythonNativeCheckInputs ? pkgs: [ ],
             torchVersions ? torchVersions',
@@ -94,22 +101,32 @@
                 default = devShells.${shellTorch};
                 test = testShells.${shellTorch};
                 devShells = build.torchDevShells {
-                  inherit path pythonCheckInputs pythonNativeCheckInputs;
+                  inherit
+                    path
+                    doGetKernelCheck
+                    pythonCheckInputs
+                    pythonNativeCheckInputs
+                    ;
                   rev = revUnderscored;
                 };
                 testShells = build.torchExtensionShells {
-                  inherit path pythonCheckInputs pythonNativeCheckInputs;
+                  inherit
+                    path
+                    doGetKernelCheck
+                    pythonCheckInputs
+                    pythonNativeCheckInputs
+                    ;
                   rev = revUnderscored;
                 };
               };
               packages = rec {
                 default = bundle;
                 bundle = build.buildTorchExtensionBundle {
-                  inherit path;
+                  inherit path doGetKernelCheck;
                   rev = revUnderscored;
                 };
                 redistributable = build.buildDistTorchExtensions {
-                  inherit path;
+                  inherit path doGetKernelCheck;
                   buildSets = buildSetPerSystem'.${system};
                   rev = revUnderscored;
                 };

--- a/lib/torch-extension-noarch/default.nix
+++ b/lib/torch-extension-noarch/default.nix
@@ -3,6 +3,10 @@
   extensionName,
   rev,
 
+  # Whether to run get-kernel-check.
+  doGetKernelCheck ? true,
+
+  lib,
   build2cmake,
   get-kernel-check,
   torch,
@@ -19,10 +23,13 @@ stdenv.mkDerivation (prevAttrs: {
   # also get torch as a build input.
   buildInputs = [ torch ];
 
-  nativeBuildInputs = [
-    build2cmake
-    get-kernel-check
-  ];
+  nativeBuildInputs =
+    [
+      build2cmake
+    ]
+    ++ lib.optionals doGetKernelCheck [
+      get-kernel-check
+    ];
 
   dontBuild = true;
 

--- a/lib/torch-extension/default.nix
+++ b/lib/torch-extension/default.nix
@@ -3,6 +3,9 @@
   nvccThreads,
   rev,
 
+  # Whether to run get-kernel-check.
+  doGetKernelCheck ? true,
+
   # Wheter to strip rpath for non-nix use.
   stripRPath ? false,
 
@@ -81,11 +84,13 @@ stdenv.mkDerivation (prevAttrs: {
 
   nativeBuildInputs =
     [
-      get-kernel-check
       kernel-abi-check
       cmake
       ninja
       build2cmake
+    ]
+    ++ lib.optionals doGetKernelCheck [
+      get-kernel-check
     ]
     ++ lib.optionals cudaSupport [
       cmakeNvccThreadsHook


### PR DESCRIPTION
This is a 'backdoor' for kernels that require a GPU during import (which is not available in the build sandbox).