### PR TITLE
Set `HOME` in get-kernel-check-hook

### DIFF
--- a/pkgs/get-kernel-check/get-kernel-check-hook.sh
+++ b/pkgs/get-kernel-check/get-kernel-check-hook.sh
@@ -19,6 +19,10 @@ _getKernelCheckHook() {
     TMPDIR=$(mktemp -d -t test.XXXXXX) || exit 1
     trap "rm -rf '$TMPDIR'" EXIT
 
+    # Some kernels want to write stuff (especially when they use Triton).
+    HOME=$(mktemp -d -t test.XXXXXX) || exit 1
+    trap "rm -rf '$HOME'" EXIT
+
     # Emulate the bundle layout that kernels expects. This even works
     # for universal kernels, since kernels checks the non-universal
     # path first.


### PR DESCRIPTION
Some kernels (especially those using Triton decorators) want to write to the home directory during import.