### PR TITLE
Pass default versions set `torchVersions`

### DIFF
--- a/examples/relu-specific-torch/flake.nix
+++ b/examples/relu-specific-torch/flake.nix
@@ -13,7 +13,7 @@
     kernel-builder.lib.genFlakeOutputs {
       path = ./.;
       rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
-      torchVersions = [
+      torchVersions = defaultVersions: [
         {
           torchVersion = "2.7";
           cudaVersion = "12.8";

--- a/flake.nix
+++ b/flake.nix
@@ -81,10 +81,13 @@
             doGetKernelCheck ? true,
             pythonCheckInputs ? pkgs: [ ],
             pythonNativeCheckInputs ? pkgs: [ ],
-            torchVersions ? torchVersions',
+            torchVersions ? _: torchVersions',
           }:
+          assert
+            (builtins.isFunction torchVersions)
+            || abort "`torchVersions` must be a function taking one argument (the default version set)";
           let
-            buildSetPerSystem' = mkBuildSetsPerSystem torchVersions;
+            buildSetPerSystem' = mkBuildSetsPerSystem (torchVersions torchVersions');
             buildPerSystem = mkBuildPerSystem buildSetPerSystem';
           in
           flake-utils.lib.eachSystem systems (


### PR DESCRIPTION
`genFlakeOutputs` accepts a `torchVersions` attr to define custom versions. However, up till this change it took a list. This made it impossible to add the existing set of versions. With this change `torchVersions` must be a one-arg function. It will be passed the default version set, making it possible to extend the versions:

```nix
kernel-builder.lib.genFlakeOutputs {
  # ...

  torchVersions = defaultVersions: defaultVersions ++ [
    # Custom versions
  ];
};
```