### PR TITLE
kernel devshell: automatically create venv

### DIFF
--- a/lib/build.nix
+++ b/lib/build.nix
@@ -285,6 +285,7 @@ rec {
               [
                 build2cmake
                 kernel-abi-check
+                python3.pkgs.venvShellHook
               ]
               ++ (pythonNativeCheckInputs python3.pkgs);
             buildInputs = with pkgs; [ python3.pkgs.pytest ] ++ (pythonCheckInputs python3.pkgs);
@@ -293,6 +294,7 @@ rec {
               PYTORCH_ROCM_ARCH = lib.concatStringsSep ";" buildSet.torch.rocmArchs;
               HIP_PATH = pkgs.rocmPackages.clr;
             };
+            venvDir = "./.venv";
           };
         };
       filteredBuildSets = applicableBuildSets (readBuildConfig path) buildSets;


### PR DESCRIPTION
When you enter a kernel devshell, you typically want to pip install the kernel to continue developing it. However, the devshell is immutable and you have to create a venv manually. Even more annoyingly, you have to activate the venv every time you enter the devshell.

Fix this by using `venvShellHook` to automatically create/activate a venv.