### PR TITLE
Add a full ReLU example with backprop and `torch.compile` support

### DIFF
--- a/examples/relu-backprop-compile/build.toml
+++ b/examples/relu-backprop-compile/build.toml
@@ -1,0 +1,30 @@
+[general]
+name = "relu"
+universal = false
+
+[torch]
+src = [
+    "torch-ext/torch_binding.cpp",
+    "torch-ext/torch_binding.h",
+]
+
+[kernel.activation]
+backend = "cuda"
+depends = ["torch"]
+src = ["relu_cuda/relu.cu"]
+
+[kernel.activation_rocm]
+backend = "rocm"
+rocm-archs = [
+    "gfx906",
+    "gfx908",
+    "gfx90a",
+    "gfx940",
+    "gfx941",
+    "gfx942",
+    "gfx1030",
+    "gfx1100",
+    "gfx1101",
+]
+depends = ["torch"]
+src = ["relu_cuda/relu.cu"]

--- a/examples/relu-backprop-compile/flake.nix
+++ b/examples/relu-backprop-compile/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Flake for ReLU kernel";
+
+  inputs = {
+    kernel-builder.url = "path:../..";
+  };
+
+  outputs =
+    {
+      self,
+      kernel-builder,
+    }:
+    kernel-builder.lib.genFlakeOutputs {
+      path = ./.;
+      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
+    };
+}

--- a/examples/relu-backprop-compile/relu_cuda/relu.cu
+++ b/examples/relu-backprop-compile/relu_cuda/relu.cu
@@ -1,0 +1,103 @@
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <torch/all.h>
+#include <c10/util/BFloat16.h>
+#include <c10/util/Half.h>
+
+#include <cmath>
+
+template<typename T>
+__global__ void relu_fwd_kernel(T *__restrict__ out,
+                                T const *__restrict__ input, int const d) {
+  int64_t const token_idx = blockIdx.x;
+  for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
+    int64_t const offset = token_idx * d + idx;
+    auto x = input[offset];
+    // Casting to float because `>` cannot be resolved BFloat16.
+    out[offset] = static_cast<float>(x) > 0.0f ? x : static_cast<T>(0);
+  }
+}
+
+template<typename T>
+__global__ void relu_bwd_kernel(T *__restrict__ grad_input,
+                                T const *__restrict__ grad_output,
+                                T const *__restrict__ input, int const d) {
+  int64_t const token_idx = blockIdx.x;
+  for (int64_t idx = threadIdx.x; idx < d; idx += blockDim.x) {
+    int64_t const offset = token_idx * d + idx;
+    auto x = static_cast<float>(input[offset]);
+    auto grad_out = grad_output[offset];
+    grad_input[offset] = static_cast<float>(x) > 0.0f ? grad_out : static_cast<T>(0);
+  }
+}
+
+torch::Tensor relu_fwd(torch::Tensor const &input) {
+  TORCH_CHECK(input.device().is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Float ||
+              input.scalar_type() == at::ScalarType::Double ||
+              input.scalar_type() == at::ScalarType::Half ||
+              input.scalar_type() == at::ScalarType::BFloat16,
+              "relu_kernel supports float32, float64, float16, and bfloat16");
+
+  torch::Tensor out = torch::empty_like(input);
+
+  int d = input.size(-1);
+  int64_t num_tokens = input.numel() / d;
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  at::cuda::OptionalCUDAGuard const device_guard(device_of(input));
+  cudaStream_t const stream = at::cuda::getCurrentCUDAStream();
+  
+  // Dispatch based on scalar type
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "relu_fwd_kernel", [&] {
+    relu_fwd_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        out.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(), 
+        d);
+  });
+  
+  return out;
+}
+
+torch::Tensor relu_bwd(torch::Tensor const &grad_output, torch::Tensor const &input) {
+  TORCH_CHECK(input.device().is_cuda(), "input must be a CUDA tensor");
+  TORCH_CHECK(input.is_contiguous(), "input must be contiguous");
+  
+  // Check for supported data types
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Float ||
+              input.scalar_type() == at::ScalarType::Double ||
+              input.scalar_type() == at::ScalarType::Half ||
+              input.scalar_type() == at::ScalarType::BFloat16,
+              "relu_bwd_kernel supports float32, float64, float16, and bfloat16");
+  
+  TORCH_CHECK(grad_output.device().is_cuda(), "grad_output must be a CUDA tensor");
+  TORCH_CHECK(grad_output.is_contiguous(), "grad_output must be contiguous");
+  TORCH_CHECK(grad_output.scalar_type() == input.scalar_type(),
+              "grad_output and input must have the same data type");
+  
+  TORCH_CHECK(input.sizes() == grad_output.sizes(),
+              "input and grad_output must have the same shape");
+  
+  TORCH_CHECK(input.device() == grad_output.device(),
+              "input and grad_output must be on the same device");
+
+  torch::Tensor grad_input = torch::empty_like(input);
+
+  int d = input.size(-1);
+  int64_t num_tokens = input.numel() / d;
+  dim3 grid(num_tokens);
+  dim3 block(std::min(d, 1024));
+  at::cuda::OptionalCUDAGuard const device_guard(device_of(input));
+  cudaStream_t const stream = at::cuda::getCurrentCUDAStream();
+  
+  AT_DISPATCH_FLOATING_TYPES_AND2(at::ScalarType::Half, at::ScalarType::BFloat16, input.scalar_type(), "relu_bwd_kernel", [&] {
+    relu_bwd_kernel<scalar_t><<<grid, block, 0, stream>>>(
+        grad_input.data_ptr<scalar_t>(),
+        grad_output.data_ptr<scalar_t>(),
+        input.data_ptr<scalar_t>(), 
+        d);
+  });
+  
+  return grad_input;
+}

--- a/examples/relu-backprop-compile/tests/kernels/allclose_default.py
+++ b/examples/relu-backprop-compile/tests/kernels/allclose_default.py
@@ -1,0 +1,14 @@
+import torch
+
+# Reference default values of atol and rtol are from
+# https://github.com/pytorch/pytorch/blob/6d96beb6bec24d73ee3f080bac54d2104068f675/test/test_transformers.py#L67
+default_atol = {torch.float16: 1e-3, torch.bfloat16: 1e-3, torch.float: 1e-5}
+default_rtol = {torch.float16: 1e-3, torch.bfloat16: 1.6e-2, torch.float: 1.3e-6}
+
+
+def get_default_atol(output) -> float:
+    return default_atol[output.dtype]
+
+
+def get_default_rtol(output) -> float:
+    return default_rtol[output.dtype]

--- a/examples/relu-backprop-compile/tests/test_relu.py
+++ b/examples/relu-backprop-compile/tests/test_relu.py
@@ -1,0 +1,158 @@
+import platform
+
+import pytest
+import torch
+import torch.nn.functional as F
+from torch.library import opcheck
+
+import relu
+
+
+def get_device():
+    if platform.system() == "Darwin":
+        return torch.device("mps")
+    elif hasattr(torch, "xpu") and torch.xpu.is_available():
+        return torch.device("xpu")
+    else:
+        return torch.device("cuda")
+
+
+DTYPES = [
+    torch.float32,
+    torch.float64,
+    torch.float16,
+    torch.bfloat16,
+]
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_relu_forward(dtype):
+    device = get_device()
+    x = torch.randn(1024, 1024, dtype=dtype, device=device)
+    expected = F.relu(x)
+    actual = relu.relu(x)
+    torch.testing.assert_close(expected, actual)
+
+
+def test_relu_gradient_numerical():
+    device = get_device()
+    x = torch.randn(32, 32, dtype=torch.float64, device=device, requires_grad=True)
+    assert torch.autograd.gradcheck(relu.relu, x)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_relu_gradient_large_tensor(dtype):
+    device = get_device()
+    x = torch.randn(1024, 1024, dtype=dtype, device=device, requires_grad=True)
+    y = relu.relu(x)
+    loss = y.sum()
+    loss.backward()
+
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+
+    expected_grad = torch.where(
+        x > 0,
+        torch.tensor(1.0, dtype=dtype, device=device),
+        torch.tensor(0.0, dtype=dtype, device=device),
+    )
+    torch.testing.assert_close(x.grad, expected_grad)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_relu_gradient_comparison(dtype):
+    device = get_device()
+    x_data = torch.tensor(
+        [[-2.0, -1.0, 0.0, 1.0, 2.0], [0.5, -0.5, 1.5, -1.5, 0.0]],
+        dtype=dtype,
+        device=device,
+    )
+
+    x_kernel = x_data.clone().requires_grad_(True)
+    y_kernel = relu.relu(x_kernel)
+    loss_custom = y_kernel.sum()
+    loss_custom.backward()
+
+    x_torch = x_data.clone().requires_grad_(True)
+    y_torch = F.relu(x_torch)
+    loss_torch = y_torch.sum()
+    loss_torch.backward()
+
+    torch.testing.assert_close(y_kernel, y_torch)
+    torch.testing.assert_close(x_kernel.grad, x_torch.grad)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_relu_backward_chain(dtype):
+    device = get_device()
+    x = torch.randn(64, 128, dtype=dtype, device=device, requires_grad=True)
+    y = relu.relu(x)
+    z = y * 2.0
+    loss = z.sum()
+    loss.backward()
+
+    assert x.grad is not None
+    assert x.grad.shape == x.shape
+
+    expected_grad = torch.where(
+        x > 0,
+        torch.tensor(2.0, dtype=dtype, device=device),
+        torch.tensor(0.0, dtype=dtype, device=device),
+    )
+    torch.testing.assert_close(x.grad, expected_grad)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (32, 64),
+        (1, 1024),
+        (128, 256),
+        (8, 8, 16),
+    ],
+)
+def test_relu_fwd_opcheck(shape, dtype):
+    device = get_device()
+    x = torch.randn(shape, dtype=dtype, device=device, requires_grad=True)
+    opcheck(relu.ops.relu_fwd, (x,))
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_relu_torch_compile(dtype):
+    device = get_device()
+
+    class SimpleModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = torch.nn.Linear(1024, 1024)
+
+        def forward(self, x):
+            return relu.relu(self.linear(x))
+
+    model = SimpleModel().to(device).to(dtype)
+    compiled_model = torch.compile(model, fullgraph=True)
+
+    x = torch.randn((1024, 1024), dtype=dtype, device=device, requires_grad=True)
+
+    y_original = model(x)
+    y_compiled = compiled_model(x)
+
+    torch.testing.assert_close(y_original, y_compiled)
+
+    loss_original = y_original.sum()
+    loss_compiled = y_compiled.sum()
+
+    if x.grad is not None:
+        x.grad.zero_()
+
+    loss_original.backward(retain_graph=True)
+    assert x.grad is not None
+    grad_original = x.grad.clone()
+
+    x.grad.zero_()
+    loss_compiled.backward()
+    assert x.grad is not None
+    grad_compiled = x.grad.clone()
+
+    torch.testing.assert_close(grad_original, grad_compiled)

--- a/examples/relu-backprop-compile/torch-ext/relu/__init__.py
+++ b/examples/relu-backprop-compile/torch-ext/relu/__init__.py
@@ -1,0 +1,33 @@
+import torch
+from torch.library import register_autograd
+
+from ._ops import ops, add_op_namespace_prefix
+
+
+@torch.library.register_fake(add_op_namespace_prefix("relu_fwd"))
+def relu_fwd_fake(input: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(input)
+
+
+@torch.library.register_fake(add_op_namespace_prefix("relu_bwd"))
+def relu_bwd_fake(grad_output: torch.Tensor, input: torch.Tensor) -> torch.Tensor:
+    return torch.empty_like(input)
+
+
+def relu(x: torch.Tensor) -> torch.Tensor:
+    return ops.relu_fwd(x)
+
+
+def _setup_context(ctx, inputs, output):
+    ctx.save_for_backward(*inputs)
+
+
+def _backward(ctx, grad_outputs: torch.Tensor):
+    (input,) = ctx.saved_tensors
+    grad_outputs_contiguous = grad_outputs.contiguous()
+    return ops.relu_bwd(grad_outputs_contiguous, input)
+
+
+register_autograd(
+    add_op_namespace_prefix("relu_fwd"), _backward, setup_context=_setup_context
+)

--- a/examples/relu-backprop-compile/torch-ext/torch_binding.cpp
+++ b/examples/relu-backprop-compile/torch-ext/torch_binding.cpp
@@ -1,0 +1,15 @@
+#include <torch/library.h>
+
+#include "registration.h"
+#include "torch_binding.h"
+
+TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
+  ops.def("relu_fwd(Tensor input) -> Tensor");
+  ops.def("relu_bwd(Tensor grad_output, Tensor input) -> Tensor");
+#if defined(CUDA_KERNEL) || defined(ROCM_KERNEL)
+  ops.impl("relu_fwd", torch::kCUDA, &relu_fwd);
+  ops.impl("relu_bwd", torch::kCUDA, &relu_bwd);
+#endif
+}
+
+REGISTER_EXTENSION(TORCH_EXTENSION_NAME)

--- a/examples/relu-backprop-compile/torch-ext/torch_binding.h
+++ b/examples/relu-backprop-compile/torch-ext/torch_binding.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <torch/torch.h>
+
+torch::Tensor relu_fwd(torch::Tensor const &input);
+torch::Tensor relu_bwd(torch::Tensor const &grad_output, torch::Tensor const &input);


### PR DESCRIPTION
The existing `examples/relu` is made to be as simple as possible, using the absolute minimum to get a CUDA/ROCm/XPU kernel working. However, real-world kernels often also have to provide backprop and `torch.compile` support.

This change adds an example of an extended ReLU kernel that can backpropagate and can be compiled with `torch.compile`.