### PR TITLE
Move kernel flake outputs generation to a separate file

### DIFF
--- a/lib/gen-flake-outputs.nix
+++ b/lib/gen-flake-outputs.nix
@@ -1,0 +1,77 @@
+{
+  build,
+  buildSet,
+  system,
+
+  runCommand,
+
+  path,
+  rev,
+
+  doGetKernelCheck,
+  pythonCheckInputs,
+  pythonNativeCheckInputs,
+}:
+
+let
+  revUnderscored = builtins.replaceStrings [ "-" ] [ "_" ] rev;
+  shellTorch =
+    if system == "aarch64-darwin" then "torch28-metal-${system}" else "torch28-cxx11-cu126-${system}";
+in
+
+{
+  devShells = rec {
+    default = devShells.${shellTorch};
+    test = testShells.${shellTorch};
+    devShells = build.torchDevShells {
+      inherit
+        path
+        doGetKernelCheck
+        pythonCheckInputs
+        pythonNativeCheckInputs
+        ;
+      rev = revUnderscored;
+    };
+    testShells = build.torchExtensionShells {
+      inherit
+        path
+        doGetKernelCheck
+        pythonCheckInputs
+        pythonNativeCheckInputs
+        ;
+      rev = revUnderscored;
+    };
+  };
+  packages = rec {
+    default = bundle;
+    bundle = build.buildTorchExtensionBundle {
+      inherit path doGetKernelCheck;
+      rev = revUnderscored;
+    };
+    redistributable = build.buildDistTorchExtensions {
+      inherit path doGetKernelCheck;
+      buildSets = buildSet;
+      rev = revUnderscored;
+    };
+    buildTree =
+      let
+        src = build.mkSourceSet path;
+      in
+      runCommand "torch-extension-build-tree"
+        {
+          nativeBuildInputs = [ buildSet.pkgs.build2cmake ];
+          inherit src;
+          meta = {
+            description = "Build tree for torch extension with source files and CMake configuration";
+          };
+        }
+        ''
+          # Copy sources
+          install -dm755 $out/src
+          cp -r $src/. $out/src/
+
+          # Generate cmake files
+          build2cmake generate-torch --ops-id "${revUnderscored}" $src/build.toml $out --force
+        '';
+  };
+}


### PR DESCRIPTION
`flake.nix` was getting a bit unwieldy and I want to add more stuff to the flake generation function, so it seems like a good time to separate it.