### PR TITLE
Add build-and-copy package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,15 @@ Then quick start a build with:
 
 ```bash
 cd examples/activation
-nix build . \
+nix run .#build-and-copy \
   --override-input kernel-builder github:huggingface/kernel-builder \
   --max-jobs 8 \
   -j 8 \
   -L
 ```
 
-we also provide Docker containers for CI builds. For a quick build:
+The compiled kernel will then be available in the local `build/` directory.
+We also provide Docker containers for CI builds. For a quick build:
 
 ```bash
 # Using the prebuilt container

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -43,13 +43,15 @@ are not using NixOS, [make sure that the CUDA driver is visible](https://danield
 
 ## Building kernels with Nix
 
-A kernel that has a `flake.nix` file can be built with `nix build`.
-For example:
+A kernel that has a `flake.nix` file can be built with the `build-and-copy`
+command. For example:
 
 ```bash
 cd examples/activation
-nix build . -L
+nix run .#build-and-copy -L
 ```
+
+The compiled kernel will then be in the local `build/` directory.
 
 ## Shell for local development
 

--- a/lib/gen-flake-outputs.nix
+++ b/lib/gen-flake-outputs.nix
@@ -3,6 +3,7 @@
   buildSet,
   system,
 
+  writeScriptBin,
   runCommand,
 
   path,
@@ -44,6 +45,26 @@ in
   };
   packages = rec {
     default = bundle;
+
+    build-and-copy = writeScriptBin "build-and-copy" ''
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      if [ ! -d build ]; then
+        mkdir build
+      fi
+
+      for build_variant in ${bundle}/*; do
+        if [ -e build/$build_variant ]; then
+          rm -rf build/$build_variant
+        fi
+
+        cp -r $build_variant build/
+      done
+
+      chmod -R +w build
+    '';
+
     bundle = build.buildTorchExtensionBundle {
       inherit path doGetKernelCheck;
       rev = revUnderscored;


### PR DESCRIPTION
Running `nix run .#build-and-copy` will build the kernel and copy the results to the `build` directory in the current directory. Existing build variants will be replaced.