### PR TITLE
add xpu support in nix build

### DIFF
--- a/build2cmake/src/templates/xpu/preamble.cmake
+++ b/build2cmake/src/templates/xpu/preamble.cmake
@@ -33,7 +33,7 @@ endif()
 
 # Check for Intel XPU support in PyTorch
 run_python(XPU_AVAILABLE
-  "import torch; print('true' if hasattr(torch, 'xpu') and torch.xpu.is_available() else 'false')"
+  "import torch; print('true' if hasattr(torch, 'xpu') else 'false')"
   "Failed to check XPU availability")
 
 if(NOT XPU_AVAILABLE STREQUAL "true")

--- a/lib/build-sets.nix
+++ b/lib/build-sets.nix
@@ -15,6 +15,7 @@ let
     isCuda
     isMetal
     isRocm
+    isXpu
     ;
 
   # All build configurations supported by Torch.
@@ -39,6 +40,12 @@ let
     in
     lib.unique (builtins.map (torchVersion: torchVersion.rocmVersion) withRocm);
 
+  xpuVersions =
+    let
+      withXpu = builtins.filter (torchVersion: torchVersion ? xpuVersion) torchVersions;
+    in
+    lib.unique (builtins.map (torchVersion: torchVersion.xpuVersion) withXpu);
+
   flattenVersion = version: lib.replaceStrings [ "." ] [ "_" ] (lib.versions.pad 2 version);
 
   # An overlay that overides CUDA to the given version.
@@ -50,12 +57,16 @@ let
     rocmPackages = super."rocmPackages_${flattenVersion rocmVersion}";
   };
 
+  overlayForXpuVersion = xpuVersion: self: super: {
+    xpuPackages = super."xpuPackages_${flattenVersion xpuVersion}";
+  };
   # Construct the nixpkgs package set for the given versions.
   pkgsForVersions =
     buildConfig@{
       cudaVersion ? null,
       metal ? false,
       rocmVersion ? null,
+      xpuVersion ? null,
       torchVersion,
       cxx11Abi,
       system,
@@ -69,6 +80,8 @@ let
           pkgsByRocmVer.${rocmVersion}
         else if isMetal buildConfig then
           pkgsForMetal
+        else if isXpu buildConfig then
+          pkgsByXpuVer.${xpuVersion}
         else
           throw "No compute framework set in Torch version";
       torch = pkgs.python3.pkgs."torch_${flattenVersion torchVersion}".override {
@@ -83,6 +96,26 @@ let
         bundleBuild
         ;
     };
+  pkgsForXpuVersions =
+    xpuVersions:
+    builtins.listToAttrs (
+      map (xpuVersion: {
+        name = xpuVersion;
+        value = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            xpuSupport = true;
+          };
+          overlays = [
+            hf-nix
+            overlay
+            (overlayForXpuVersion xpuVersion)
+          ];
+        };
+      }) xpuVersions
+    );
+  pkgsByXpuVer = pkgsForXpuVersions xpuVersions;
 
   pkgsForMetal = import nixpkgs {
     inherit system;

--- a/lib/build-variants.nix
+++ b/lib/build-variants.nix
@@ -5,6 +5,7 @@ let
     isCuda
     isMetal
     isRocm
+    isXpu
     ;
 in
 rec {
@@ -16,8 +17,10 @@ rec {
       "metal"
     else if buildConfig ? "rocmVersion" then
       "rocm"
+    else if buildConfig ? xpuVersion then
+      "xpu"
     else
-      throw "Could not find compute framework: no CUDA or ROCm version specified and Metal is not enabled";
+      throw "Could not find compute framework: no CUDA, ROCm, XPU version specified and Metal is not enabled";
 
   # Build variants included in bundle builds.
   buildVariants =
@@ -31,6 +34,8 @@ rec {
           "rocm${flattenVersion (lib.versions.majorMinor version.rocmVersion)}"
         else if isMetal version then
           "metal"
+        else if isXpu version then
+          "xpu${flattenVersion (lib.versions.majorMinor version.xpuVersion)}"
         else
           throw "No compute framework set in Torch version";
       buildName =

--- a/lib/build-version.nix
+++ b/lib/build-version.nix
@@ -12,10 +12,24 @@ let
   cudaVersion = torch: "cu${flattenVersion torch.cudaPackages.cudaMajorMinorVersion}";
   rocmVersion =
     torch: "rocm${flattenVersion (lib.versions.majorMinor torch.rocmPackages.rocm.version)}";
-  gpuVersion = torch: (if torch.cudaSupport then cudaVersion else rocmVersion) torch;
   torchVersion = torch: flattenVersion torch.version;
+  xpuVersion =
+    torch:
+    "xpu${flattenVersion (lib.versions.majorMinor pkgs.xpuPackages.intel-oneapi-dpcpp-cpp.version)}";
+  gpuVersion =
+    torch:
+    if torch.cudaSupport then
+      cudaVersion torch
+    else if (torch ? rocmPackages) && (torch.rocmSupport or false) then
+      rocmVersion torch
+    else if (pkgs ? xpuPackages) && (pkgs.config.xpuSupport or false) then
+      xpuVersion torch
+    else
+      null;
 in
 if pkgs.stdenv.hostPlatform.isDarwin then
   "torch${torchVersion torch}-metal-${targetPlatform}"
-else
+else if gpuVersion torch != null then
   "torch${torchVersion torch}-${abi torch}-${gpuVersion torch}-${targetPlatform}"
+else
+  throw "No supported GPU framework (CUDA, ROCm, XPU, Metal) detected for build-version.nix"

--- a/lib/build.nix
+++ b/lib/build.nix
@@ -16,7 +16,12 @@ let
   supportedCudaCapabilities = builtins.fromJSON (
     builtins.readFile ../build2cmake/src/cuda_supported_archs.json
   );
-  inherit (import ./torch-version-utils.nix { inherit lib; }) isCuda isMetal isRocm;
+  inherit (import ./torch-version-utils.nix { inherit lib; })
+    isCuda
+    isMetal
+    isRocm
+    isXpu
+    ;
 in
 rec {
   resolveDeps = import ./deps.nix { inherit lib; };
@@ -45,11 +50,13 @@ rec {
         cuda = false;
         metal = false;
         rocm = false;
+        xpu = false;
       };
     in
     lib.foldl (backends: kernel: backends // { ${kernelBackend kernel} = true; }) init kernels;
 
   readBuildConfig = path: validateBuildConfig (readToml (path + "/build.toml"));
+  tracedReadBuildConfig = path: readBuildConfig path;
 
   srcFilter =
     src: name: type:
@@ -75,6 +82,7 @@ rec {
             (isCuda buildSet.buildConfig && backends'.cuda)
             || (isRocm buildSet.buildConfig && backends'.rocm)
             || (isMetal buildSet.buildConfig && backends'.metal)
+            || (isXpu buildSet.buildConfig && backends'.xpu)
             || (buildConfig.general.universal or false);
           cudaVersionSupported =
             !(isCuda buildSet.buildConfig)
@@ -120,6 +128,8 @@ rec {
       );
       stdenv =
         if pkgs.stdenv.hostPlatform.isDarwin then
+          pkgs.stdenv
+        else if lib.any (k: k.backend == "xpu") (lib.attrValues buildConfig.kernel) then
           pkgs.stdenv
         else if oldLinuxCompat then
           pkgs.stdenvGlibc_2_27
@@ -234,7 +244,13 @@ rec {
         let
           pkgs = buildSet.pkgs;
           rocmSupport = pkgs.config.rocmSupport or false;
-          stdenv = if rocmSupport then pkgs.stdenv else pkgs.cudaPackages.backendStdenv;
+          stdenv =
+            if rocmSupport then
+              pkgs.stdenv
+            else if isXpu buildSet.buildConfig then
+              pkgs.stdenv
+            else
+              pkgs.cudaPackages.backendStdenv;
           mkShell = pkgs.mkShell.override { inherit stdenv; };
         in
         {
@@ -274,7 +290,14 @@ rec {
         let
           pkgs = buildSet.pkgs;
           rocmSupport = pkgs.config.rocmSupport or false;
-          stdenv = if rocmSupport then pkgs.stdenv else pkgs.cudaPackages.backendStdenv;
+          xpuSupport = pkgs.config.xpuSupport or false;
+          stdenv =
+            if rocmSupport then
+              pkgs.stdenv
+            else if xpuSupport then
+              pkgs.stdenv
+            else
+              pkgs.cudaPackages.backendStdenv;
           mkShell = pkgs.mkShell.override { inherit stdenv; };
         in
         {

--- a/lib/torch-version-utils.nix
+++ b/lib/torch-version-utils.nix
@@ -10,4 +10,5 @@
   isCuda = version: version ? cudaVersion;
   isMetal = version: version.metal or false;
   isRocm = version: version ? rocmVersion;
+  isXpu = version: version ? xpuVersion;
 }

--- a/versions.nix
+++ b/versions.nix
@@ -42,6 +42,20 @@
 
   {
     torchVersion = "2.7";
+    xpuVersion = "2025.0.2";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    bundleBuild = true;
+  }
+  {
+    torchVersion = "2.8";
+    xpuVersion = "2025.1.3";
+    cxx11Abi = true;
+    systems = [ "x86_64-linux" ];
+    bundleBuild = true;
+  }
+  {
+    torchVersion = "2.7";
     cxx11Abi = true;
     metal = true;
     systems = [ "aarch64-darwin" ];


### PR DESCRIPTION
issue left:
relu-torch-ext> ⛔ Symbols incompatible with `manylinux_2_28` found:
relu-torch-ext>
relu-torch-ext> _ZNSt15__exception_ptr13exception_ptr10_M_releaseEv_CXXABI: 1.3.13
relu-torch-ext> _ZNSt15__exception_ptr13exception_ptr9_M_addrefEv_CXXABI: 1.3.13
relu-torch-ext> _ZNSt7__cxx1119basic_ostringstreamIcSt11char_traitsIcESaIcEEC1Ev_GLIBCXX: 3.4.26
relu-torch-ext> _ZSt21ios_base_library_initv_GLIBCXX: 3.4.32
relu-torch-ext> __libc_single_threaded_GLIBC: 2.32
relu-torch-ext> Error:
relu-torch-ext>    0: Compatibility issues found
relu-torch-ext>
relu-torch-ext> Location:
relu-torch-ext>    src/main.rs:82