### PR TITLE
Fix a regression in test shells

### DIFF
--- a/.github/workflows/build_kernel.yaml
+++ b/.github/workflows/build_kernel.yaml
@@ -47,6 +47,9 @@ jobs:
       - name: Build relu kernel (specific Torch version)
         run: ( cd examples/relu-specific-torch && nix build . )
 
+      - name: Test that we can build a test shell (e.g. that gcc corresponds to CUDA-required)
+        run: ( cd examples/relu && nix build .#devShells.x86_64-linux.test )
+
       - name: Build silu-and-mul-universal kernel
         run: ( cd examples/silu-and-mul-universal && nix build .\#redistributable.torch27-cxx11-cu126-x86_64-linux )
       - name: Copy silu-and-mul-universal kernel


### PR DESCRIPTION
The XPU support PR changed stdenv selection to choose the default stdenv when one of the kernels is an XPU kernel. However, this does not work for mixed XPU/CUDA projects, since we need to select the CUDA backend stdenv when building for CUDA.

Change the logic to always use the stdenv for the backend that we are building for.