### PR TITLE
Copy build from the bundle output, not `result/`

### DIFF
--- a/lib/gen-flake-outputs.nix
+++ b/lib/gen-flake-outputs.nix
@@ -60,7 +60,7 @@ in
           rm -rf build/$build_variant
         fi
 
-        cp -r result/$build_variant build/
+        cp -r ${bundle}/$build_variant build/
       done
 
       chmod -R +w build


### PR DESCRIPTION
`result/` could be anything.