### PR TITLE
Let kernel-builder determine the kernel revision

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -59,8 +59,8 @@ function ensure_flake_exists {
   };
   outputs = { self, kernel-builder, }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }
 FLAKE_EOF

--- a/dockerfiles/Dockerfile.user
+++ b/dockerfiles/Dockerfile.user
@@ -83,8 +83,8 @@ function ensure_flake_exists {
   
   outputs = { self, kernel-builder, }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }
 FLAKE_EOF

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -117,8 +117,8 @@ the kernel's `flake.nix` to use the `pythonCheckInputs` option:
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
 
       # The einops and numpy test dependencies are added here:
       pythonCheckInputs = pkgs: with pkgs; [ einops numpy ];

--- a/examples/activation/flake.nix
+++ b/examples/activation/flake.nix
@@ -12,7 +12,7 @@
     }:
 
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }

--- a/examples/cutlass-gemm/flake.nix
+++ b/examples/cutlass-gemm/flake.nix
@@ -11,7 +11,7 @@
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }

--- a/examples/relu-backprop-compile/flake.nix
+++ b/examples/relu-backprop-compile/flake.nix
@@ -11,7 +11,7 @@
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }

--- a/examples/relu-specific-torch/flake.nix
+++ b/examples/relu-specific-torch/flake.nix
@@ -11,8 +11,8 @@
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
       torchVersions = defaultVersions: [
         {
           torchVersion = "2.7";

--- a/examples/relu/flake.nix
+++ b/examples/relu/flake.nix
@@ -11,7 +11,7 @@
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }

--- a/examples/silu-and-mul-universal/flake.nix
+++ b/examples/silu-and-mul-universal/flake.nix
@@ -11,7 +11,7 @@
       kernel-builder,
     }:
     kernel-builder.lib.genFlakeOutputs {
+      inherit self;
       path = ./.;
-      rev = self.shortRev or self.dirtyShortRev or self.lastModifiedDate;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,8 @@
         genFlakeOutputs =
           {
             path,
-            rev,
+            rev ? null,
+            self ? null,
 
             # This option is not documented on purpose. You should not use it,
             # if a kernel cannot be imported, it is non-compliant. This is for
@@ -97,6 +98,7 @@
                 system
                 path
                 rev
+                self
                 doGetKernelCheck
                 pythonCheckInputs
                 pythonNativeCheckInputs


### PR DESCRIPTION
This allows us to use date-based revisions and thus ops identifiers in the future.