### PR TITLE
Fix docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ We also provide Docker containers for CI builds. For a quick build:
 # Using the prebuilt container
 cd examples/activation
 docker run --rm \
-  -v $(pwd):/app \
-  -w /app \
+  -v $(pwd)/../..:/app \
+  -w /app/examples/activation \
   ghcr.io/huggingface/kernel-builder:{SHA} \
   build
 ```


### PR DESCRIPTION
This is something I just stumbled upon when trying to get into building custom kernels.

The flake in this example (and others, didn't check all) reference kernel-builder via `../..` which will fail when only the flake is mounted into `/app` of the container. Mounting the whole repo and changing to the example directory in the container works, though.