### PR TITLE
fix: update docker files and readme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,8 @@ We also provide Docker containers for CI builds. For a quick build:
 # Using the prebuilt container
 cd examples/activation
 docker run --rm \
-  -v $(pwd):/app \
-  -w /app \
-  ghcr.io/huggingface/kernel-builder:{SHA} \
-  build
+  --mount type=bind,source=$(pwd),target=/kernelcode \
+  -w /kernelcode ghcr.io/huggingface/kernel-builder:main build
 ```
 
 See [dockerfiles/README.md](./dockerfiles/README.md) for more options, including a user-level container for CI/CD environments.

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix:2.23.0
+FROM nixos/nix:2.30.3
 
 # default build args
 ARG MAX_JOBS=4
@@ -8,7 +8,7 @@ ARG CORES=4
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && echo "max-jobs = $MAX_JOBS" >> /etc/nix/nix.conf \
     && echo "cores = $CORES" >> /etc/nix/nix.conf \
-    && nix profile install --impure nixpkgs#cachix nixpkgs#git-lfs nixpkgs#jq \
+    && nix profile install nixpkgs#cachix nixpkgs#git-lfs nixpkgs#jq \
     && cachix use huggingface
 # Copy external files
 COPY . /etc/src/

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix:2.18.8
+FROM nixos/nix:2.23.0
 
 # default build args
 ARG MAX_JOBS=4
@@ -8,7 +8,7 @@ ARG CORES=4
 RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && echo "max-jobs = $MAX_JOBS" >> /etc/nix/nix.conf \
     && echo "cores = $CORES" >> /etc/nix/nix.conf \
-    && nix profile install nixpkgs#cachix nixpkgs#git-lfs nixpkgs#jq \
+    && nix profile install --impure nixpkgs#cachix nixpkgs#git-lfs nixpkgs#jq \
     && cachix use huggingface
 # Copy external files
 COPY . /etc/src/
@@ -100,21 +100,15 @@ function build_extension {
   # Make sure the build is up to date
   nix run github:huggingface/kernel-builder#update-build -- build.toml
 
-  # only do the following if flake.lock exists
-
-  # if the lock file exists
+  # Determine override from flake.nix only
   override=""
-  if [ -f flake.lock ]; then
-    # check the type of kernel-builder in flake.lock
-    kernel_url_type=$(cat flake.lock | jq -r '.nodes["kernel-builder"].locked.type')
-    echo "Kernel URL type: $kernel_url_type"
-
-    # If the type is "path", compute the nar hash and set override
-    if [ "$kernel_url_type" = "path" ]; then
-      kernel_url_path=$(cat flake.lock | jq -r '.nodes["kernel-builder"].locked.path')
-      nar_hash=$(nix-hash --type sha256 --base64 "$kernel_url_path")
-      override="--override-input kernel-builder path:../..?narHash=sha256-$nar_hash"
-    fi
+  # check if using a local path for kernel-builder
+  is_using_path=$(grep -q 'kernel-builder.url *= *"path:' flake.nix && echo "yes" || echo "no")
+  if [ "$is_using_path" = "yes" ]; then
+    override="--override-input kernel-builder github:huggingface/kernel-builder"
+    echo "Detected local path for kernel-builder in flake.nix, overriding to use GitHub source."
+  else
+    echo "No local path for kernel-builder detected in flake.nix."
   fi
 
   echo "Building with Nix..."

--- a/dockerfiles/Dockerfile.user
+++ b/dockerfiles/Dockerfile.user
@@ -1,4 +1,4 @@
-FROM nixos/nix:2.18.8
+FROM nixos/nix:2.23.0
 
 # default build args
 ARG MAX_JOBS=1
@@ -18,7 +18,7 @@ RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && mkdir -p /nix/var/nix/gcroots/per-user/nixuser \
     && chown -R 1000:1000 /home/nixuser /nix/var/nix/profiles/per-user/nixuser /nix/var/nix/gcroots/per-user/nixuser \
     # Install necessary packages
-    && nix profile install nixpkgs#cachix nixpkgs#git-lfs nixpkgs#gawk \
+    && nix profile install --impure nixpkgs#cachix nixpkgs#git-lfs nixpkgs#gawk \
     && cachix use huggingface
 
 # Set permissions for Nix directories
@@ -119,6 +119,17 @@ function build_extension {
   
   # Make sure the build is up to date
   nix run github:huggingface/kernel-builder#update-build -- build.toml
+
+  # Determine override from flake.nix only
+  override=""
+  # check if using a local path for kernel-builder
+  is_using_path=$(grep -q 'kernel-builder.url *= *"path:' flake.nix && echo "yes" || echo "no")
+  if [ "$is_using_path" = "yes" ]; then
+    override="--override-input kernel-builder github:huggingface/kernel-builder"
+    echo "Detected local path for kernel-builder in flake.nix, overriding to use GitHub source."
+  else
+    echo "No local path for kernel-builder detected in flake.nix."
+  fi
 
   # Pure bundle build
   # TODO: remove the "bundle" after resolving

--- a/dockerfiles/Dockerfile.user
+++ b/dockerfiles/Dockerfile.user
@@ -1,4 +1,4 @@
-FROM nixos/nix:2.23.0
+FROM nixos/nix:2.30.3
 
 # default build args
 ARG MAX_JOBS=1
@@ -18,7 +18,7 @@ RUN echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf \
     && mkdir -p /nix/var/nix/gcroots/per-user/nixuser \
     && chown -R 1000:1000 /home/nixuser /nix/var/nix/profiles/per-user/nixuser /nix/var/nix/gcroots/per-user/nixuser \
     # Install necessary packages
-    && nix profile install --impure nixpkgs#cachix nixpkgs#git-lfs nixpkgs#gawk \
+    && nix profile install nixpkgs#cachix nixpkgs#git-lfs nixpkgs#gawk \
     && cachix use huggingface
 
 # Set permissions for Nix directories


### PR DESCRIPTION
This PR bumps the Docker images from nix 2.18 to 2.23, fixes the override logic when flake.nix points to a local path, and updates the README with a simpler Docker command that works more reliably than the old one.