### PR TITLE
Add `ci` output for generated flakes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,6 @@
           system: buildSet:
           import lib/build.nix {
             inherit (nixpkgs) lib;
-            buildSets = buildSetPerSystem.${system};
           }
         ) buildSetPerSystem;
 
@@ -104,6 +103,7 @@
                 pythonNativeCheckInputs
                 ;
               build = buildPerSystem.${system};
+              buildSets = buildSetPerSystem.${system};
             }
           );
       }


### PR DESCRIPTION
This output is like `bundle`, but only builds one variant for each framework.