### PR TITLE
fix(build2cmake): ignore untracked files when looking for modified files to suffix with `_dirty`

### DIFF
--- a/build2cmake/src/torch/ops_identifier.rs
+++ b/build2cmake/src/torch/ops_identifier.rs
@@ -19,7 +19,11 @@ fn git_identifier(target_dir: impl AsRef<Path>) -> Result<String> {
     let head = repo.head()?;
     let commit = head.peel_to_commit()?;
     let rev = commit.tree_id().to_string().chars().take(7).collect();
-    let dirty = !repo.statuses(None)?.is_empty();
+
+    let mut status_options = git2::StatusOptions::new();
+    status_options.include_untracked(false); // Ignore untracked files (like generated CMake files)
+    status_options.exclude_submodules(true);
+    let dirty = !repo.statuses(Some(&mut status_options))?.is_empty();
     Ok(if dirty { format!("{rev}_dirty") } else { rev })
 }
 


### PR DESCRIPTION
In the current flow, `build2cmake` might generates `CMake` files before this get called thus generating some changes (i.e. `statuses.is_empty() == false` if the build folder is in the source tree.


Adding options in order to soften a bit the constraint